### PR TITLE
changed lstat to stat for Windows users

### DIFF
--- a/rimraf.js
+++ b/rimraf.js
@@ -49,7 +49,7 @@ function rimraf (p, opts, cb) {
 }
 
 function rimraf_ (p, opts, cb) {
-  fs.lstat(p, function (er, s) {
+  fs.stat(p, function (er, s) {
     // if the stat fails, then assume it's already gone.
     if (er) {
       // already gone


### PR DESCRIPTION
in the function rimraf_ you used fs.lstat to test if the file is exist.
but fs.lstat may bring a bug in Windows, so i changed it to fs.stat
