### PR TITLE
Add `rimraf` binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,8 @@ errors are handled for you:
 
 It can remove stuff synchronously, too.  But that's not so good.  Use
 the async API.  It's better.
+
+## CLI
+
+If installed with `npm install rimraf -g` it can be used as a global
+command `rimraf <path>` which is useful for cross platform support.

--- a/bin.js
+++ b/bin.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+var rimraf = require('./')
+
+if (process.argv.length === 3 && process.argv[2] && process.argv[2] != '--help' && !/^\-[a-z]*h[a-z]*$/.test(process.argv[2]) && process.argv[2] != 'help' && process.argv[2] != '/?') {
+  rimraf.sync(process.argv[2])
+} else {
+  console.log('Usage: rimraf <path>')
+  console.log()
+  console.log('  Deletes all files and folders at "path" recursively.')
+  console.log()
+  console.log('Options:')
+  console.log()
+  console.log('  -h, --help    Display this usage info')
+}

--- a/package.json
+++ b/package.json
@@ -14,5 +14,6 @@
   "repository": "git://github.com/isaacs/rimraf.git",
   "scripts": {
     "test": "cd test && bash run.sh"
-  }
+  },
+  "bin": "./bin.js"
 }


### PR DESCRIPTION
As discussed, this is useful when you need a cross platform `rm -rf` without dependencies on packages that aren't distributed with node.js

[closes #22]
