### PR TITLE
Fix for EPERM on windows

### DIFF
--- a/rimraf.js
+++ b/rimraf.js
@@ -59,6 +59,7 @@ function rimraf (p, cb) {
 // If anyone ever complains about this, then I guess the strategy could
 // be made configurable somehow.  But until then, YAGNI.
 function rimraf_ (p, cb) {
+  if (process.platform === "win32") fs.chmodSync(p,666)
   fs.unlink(p, function (er) {
     if (er && er.code === "ENOENT")
       return cb()
@@ -107,6 +108,7 @@ function rmkids(p, cb) {
 // tie up the JavaScript thread and fail on excessively
 // deep directory trees.
 function rimrafSync (p) {
+  if (process.platform === "win32") fs.chmodSync(p,666)
   try {
     fs.unlinkSync(p)
   } catch (er) {


### PR DESCRIPTION
A quick and kind of hacky fix for the `EPERM` errors that occur on windows (Most commonly for me involving deleting `.git` folders). This fixes [#21](https://github.com/isaacs/rimraf/issues/21)

I've used `chmodSync` even in the async code, simply to avoid touching the existing structure, but this can be changed if desired. 

`chmod` on windows only supports `444` and `666` which toggle read only.
