### PR TITLE
Make it work with sshfs

### DIFF
--- a/rimraf.js
+++ b/rimraf.js
@@ -110,7 +110,7 @@ function rmdir (p, originalEr, cb) {
   // if we guessed wrong, and it's not a directory, then
   // raise the original error.
   fs.rmdir(p, function (er) {
-    if (er && (er.code === "ENOTEMPTY" || er.code === "EEXIST"))
+    if (er && (er.code === "ENOTEMPTY" || er.code === "EEXIST" || er.code === "EPERM"))
       rmkids(p, cb)
     else if (er && er.code === "ENOTDIR")
       cb(originalEr)
@@ -165,7 +165,7 @@ function rmdirSync (p, originalEr) {
       return
     if (er.code === "ENOTDIR")
       throw originalEr
-    if (er.code === "ENOTEMPTY" || er.code === "EEXIST")
+    if (er.code === "ENOTEMPTY" || er.code === "EEXIST" || er.code === "EPERM")
       rmkidsSync(p)
   }
 }


### PR DESCRIPTION
I'm not sure if this is a valid change for rimraf, but as per http://sourceforge.net/mailarchive/message.php?msg_id=31240176 sshfs-mounted directories return EPERM on rmdir called with non-empty dir. Hence removing non-empty directories mounted through sshfs doesn't work with rimraf, and this change makes it work.
