### PR TITLE
Fix synchronous directory removal

### DIFF
--- a/rimraf.js
+++ b/rimraf.js
@@ -181,7 +181,7 @@ function rimrafSync (p, options) {
     if (er.code === "ENOENT")
       return
     if (er.code === "EPERM")
-      return isWindows ? fixWinEPERMSync(p, er) : rmdirSync(p, er)
+      return isWindows ? fixWinEPERMSync(p, er) : rmdirSync(p, options, er)
     if (er.code !== "EISDIR")
       throw er
     rmdirSync(p, options, er)


### PR DESCRIPTION
rimraf v2.2.7 fails to remove a directory synchronously.
For example, `rimraf.sync("foo/")` does not remove `foo` directory.

This PR fixes this problem.
