### PR TITLE
fix fixWinEPERMSync. Add options. Remove chmod

### DIFF
--- a/rimraf.js
+++ b/rimraf.js
@@ -108,16 +108,7 @@ function fixWinEPERM (p, options, er, cb) {
   })
 }
 
-function fixWinEPERMSync (p, er, cb) {
-  try {
-    options.chmodSync(p, 666)
-  } catch (er2) {
-    if (er2.code === "ENOENT")
-      return
-    else
-      throw er
-  }
-
+function fixWinEPERMSync (p, options, er, cb) {
   try {
     var stats = options.statSync(p)
   } catch (er3) {
@@ -181,7 +172,7 @@ function rimrafSync (p, options) {
     if (er.code === "ENOENT")
       return
     if (er.code === "EPERM")
-      return isWindows ? fixWinEPERMSync(p, er) : rmdirSync(p, er)
+      return isWindows ? fixWinEPERMSync(p, options, er) : rmdirSync(p, er)
     if (er.code !== "EISDIR")
       throw er
     rmdirSync(p, options, er)


### PR DESCRIPTION
Hi, 
I made some changes to fixWinEPERMSync.
The options functions were not getting passed in which was causing an error.
Also, CHMOD does not mean anything in a Windows context so I have removed that also.'

Cheers
Paul
