### PR TITLE
Fixed bug: Call of rmdirSync() in rimrafSync()::EPERM

### DIFF
--- a/rimraf.js
+++ b/rimraf.js
@@ -181,7 +181,7 @@ function rimrafSync (p, options) {
     if (er.code === "ENOENT")
       return
     if (er.code === "EPERM")
-      return isWindows ? fixWinEPERMSync(p, er) : rmdirSync(p, er)
+      return isWindows ? fixWinEPERMSync(p, er) : rmdirSync(p, options, er)
     if (er.code !== "EISDIR")
       throw er
     rmdirSync(p, options, er)


### PR DESCRIPTION
Fixed bug: Call of rmdirSync() in rimrafSync()::EPERM missed to pass the 'options' variable, so nothing was deleted when using rimraf.sync.
