### PR TITLE
Option to disable glob

### DIFF
--- a/rimraf.js
+++ b/rimraf.js
@@ -35,7 +35,7 @@ function defaults (options) {
 
   options.maxBusyTries = options.maxBusyTries || 3
   options.emfileWait = options.emfileWait || 1000
-  options.enableGlob = options.enableGlob || true
+  options.disableGlob = options.disableGlob || false
 }
 
 function rimraf (p, options, cb) {
@@ -56,7 +56,7 @@ function rimraf (p, options, cb) {
   var errState = null
   var n = 0
 
-  if (!options.enableGlob || !glob.hasMagic(p))
+  if (options.disableGlob || !glob.hasMagic(p))
     return afterGlob(null, [p])
 
   fs.lstat(p, function (er, stat) {

--- a/rimraf.js
+++ b/rimraf.js
@@ -35,6 +35,7 @@ function defaults (options) {
 
   options.maxBusyTries = options.maxBusyTries || 3
   options.emfileWait = options.emfileWait || 1000
+  options.enableGlob = options.enableGlob || true
 }
 
 function rimraf (p, options, cb) {
@@ -55,7 +56,7 @@ function rimraf (p, options, cb) {
   var errState = null
   var n = 0
 
-  if (!glob.hasMagic(p))
+  if (!options.enableGlob || !glob.hasMagic(p))
     return afterGlob(null, [p])
 
   fs.lstat(p, function (er, stat) {


### PR DESCRIPTION
In some cases it might make sense to disable glob pattern matching (``*`` etc) completely in the file path.
This pull request adds the option ``disableGlob``.

Usage example:
```js
rimraf(f, {disableGlob: true}, callback);
```
