### PR TITLE
Added EPERM to delay/retry loop

### DIFF
--- a/rimraf.js
+++ b/rimraf.js
@@ -81,7 +81,7 @@ function rimraf (p, options, cb) {
     results.forEach(function (p) {
       rimraf_(p, options, function CB (er) {
         if (er) {
-          if (isWindows && (er.code === "EBUSY" || er.code === "ENOTEMPTY") &&
+          if (isWindows && (er.code === "EBUSY" || er.code === "ENOTEMPTY" || er.code === "EPERM") &&
               busyTries < options.maxBusyTries) {
             busyTries ++
             var time = busyTries * 100


### PR DESCRIPTION
issue #86: EPERM seems to be reported when something still holds a handle to a file from the folder being deleted, it might be reasonable to handle it like similar to EBUSY