### PR TITLE
Use standard style

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -4,16 +4,17 @@ var rimraf = require('./')
 
 var help = false
 var dashdash = false
-var args = process.argv.slice(2).filter(function(arg) {
-  if (dashdash)
+var args = process.argv.slice(2).filter(function (arg) {
+  if (dashdash) {
     return !!arg
-  else if (arg === '--')
+  } else if (arg === '--') {
     dashdash = true
-  else if (arg.match(/^(-+|\/)(h(elp)?|\?)$/))
+  } else if (arg.match(/^(-+|\/)(h(elp)?|\?)$/)) {
     help = true
-  else
+  } else {
     return !!arg
-});
+  }
+})
 
 if (help || args.length === 0) {
   // If they didn't ask for help, then this is not a "success"
@@ -26,15 +27,16 @@ if (help || args.length === 0) {
   log('')
   log('  -h, --help    Display this usage info')
   process.exit(help ? 0 : 1)
-} else
+} else {
   go(0)
+}
 
 function go (n) {
-  if (n >= args.length)
-    return
-  rimraf(args[n], function (er) {
-    if (er)
-      throw er
-    go(n+1)
+  if (n >= args.length) return
+
+  rimraf(args[n], function (err) {
+    if (err) throw err
+
+    go(n + 1)
   })
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "ISC",
   "repository": "git://github.com/isaacs/rimraf.git",
   "scripts": {
-    "test": "tap test/*.js"
+    "test": "standard && tap test/*.js"
   },
   "bin": "./bin.js",
   "dependencies": {
@@ -21,6 +21,7 @@
   ],
   "devDependencies": {
     "mkdirp": "^0.5.1",
+    "standard": "^5.3.1",
     "tap": "^1.3.1"
   }
 }

--- a/test/basic.js
+++ b/test/basic.js
@@ -27,9 +27,9 @@ t.test('async removal', function (t) {
   fill()
   t.ok(fs.statSync(__dirname + '/target').isDirectory())
 
-  rimraf(__dirname + '/target', function (er) {
-    if (er)
-      throw er
+  rimraf(__dirname + '/target', function (err) {
+    if (err) throw err
+
     t.throws(function () {
       fs.statSync(__dirname + '/target')
     })
@@ -45,9 +45,9 @@ t.test('glob', function (t) {
     var pattern = __dirname + '/target/f-*'
     var before = glob.sync(pattern)
     t.notEqual(before.length, 0)
-    rimraf(pattern, function (er) {
-      if (er)
-        throw er
+    rimraf(pattern, function (err) {
+      if (err) throw err
+
       var after = glob.sync(pattern)
       t.same(after, [])
       rimraf.sync(__dirname + '/target')
@@ -76,9 +76,9 @@ t.test('no glob', function (t) {
     var pattern = __dirname + '/target/f-*'
     var before = glob.sync(pattern)
     t.notEqual(before.length, 0)
-    rimraf(pattern, { disableGlob: true }, function (er) {
-      if (er)
-        throw er
+    rimraf(pattern, { disableGlob: true }, function (err) {
+      if (err) throw err
+
       var after = glob.sync(pattern)
       t.same(after, before)
       rimraf.sync(__dirname + '/target')

--- a/test/fill.js
+++ b/test/fill.js
@@ -7,14 +7,15 @@ module.exports = function () {
 
 if (module === require.main) {
   require('tap').pass('yes')
-  return
+  process.exit(0)
 }
 
 function fill (depth, files, folders, target) {
   mkdirp.sync(target)
   var o = { flag: 'wx' }
-  if (process.version.match(/^v0\.8/))
+  if (process.version.match(/^v0\.8/)) {
     o = 'utf8'
+  }
 
   for (var f = files; f > 0; f--) {
     fs.writeFileSync(target + '/f-' + depth + '-' + f, '', o)
@@ -29,13 +30,10 @@ function fill (depth, files, folders, target) {
   // file with a name that looks like a glob
   fs.writeFileSync(target + '/[a-z0-9].txt', '', o)
 
-  depth--
-  if (depth <= 0)
-    return
+  if (--depth <= 0) return
 
   for (f = folders; f > 0; f--) {
     mkdirp.sync(target + '/folder-' + depth + '-' + f)
     fill(depth, files, folders, target + '/d-' + depth + '-' + f)
   }
 }
-


### PR DESCRIPTION
Hello @isaacs,

This pull request will update your code base to follow [Javascript Standard Style](http://standardjs.com) with the goal of helping you maintain a consistent code base. It also adds a test to see that the style guide is followed that runs before the normal test, never give style feedback on a pull request again!

Standard is already in use of 1700+ npm packages, including Google's Karma and npm itself, and this pull request is a part of the goal to get the most popular packages on board. Anyone can track the status of this and help out here: feross/standard#275

Thank you for taking the time to review this patch. Standard actually managed to point out a potential problem where a variable was overwritten with `var` where it was previously defined; see line 281/290.

The reason I renamed the `er` variable to `err` is because `standard` actually checks so that you handle your errors. This only works when the argument is actually named `err` thought, but this is very standard within the Node community.

Thanks
Linus Unnebäck