### PR TITLE
Add option to use custom fs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ The first parameter will be interpreted as a globbing pattern for files. If you
 want to disable globbing you can do so with `opts.disableGlob` (defaults to
 `false`). This might be handy, for instance, if you have filenames that contain
 globbing wildcard characters.
-You can optionally pass in an alternate fs implementation by passing in opts.fs. 
-Your implementation should have opts.fs.lstat(path, cb) and opts.fs.lstatSync(path).
+You can optionally pass in an alternate fs implementation by passing in `opts.fs`. 
+Your implementation should have `opts.fs.lstat(path, cb)` and `opts.fs.lstatSync(path)`.
 
 The callback will be called with an error if there is one.  Certain
 errors are handled for you:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The first parameter will be interpreted as a globbing pattern for files. If you
 want to disable globbing you can do so with `opts.disableGlob` (defaults to
 `false`). This might be handy, for instance, if you have filenames that contain
 globbing wildcard characters.
+You can optionally pass in an alternate fs implementation by passing in opts.fs. 
+Your implementation should have opts.fs.lstat(path, cb) and opts.fs.lstatSync(path).
 
 The callback will be called with an error if there is one.  Certain
 errors are handled for you:

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   ],
   "devDependencies": {
     "mkdirp": "^0.5.1",
+    "mock-fs": "^3.5.0",
     "tap": "^1.3.1"
   }
 }

--- a/rimraf.js
+++ b/rimraf.js
@@ -3,7 +3,7 @@ rimraf.sync = rimrafSync
 
 var assert = require("assert")
 var path = require("path")
-var fs = require("fs")
+var fsx = require("fs")
 var glob = require("glob")
 
 var globOpts = {
@@ -15,7 +15,6 @@ var globOpts = {
 
 // for EMFILE handling
 var timeout = 0
-
 var isWindows = (process.platform === "win32")
 
 function defaults (options) {
@@ -27,6 +26,8 @@ function defaults (options) {
     'rmdir',
     'readdir'
   ]
+  var fs = options.fs || fsx;
+  
   methods.forEach(function(m) {
     options[m] = options[m] || fs[m]
     m = m + 'Sync'
@@ -55,8 +56,7 @@ function rimraf (p, options, cb) {
   var busyTries = 0
   var errState = null
   var n = 0
-
-  if(options.fs) fs = options.fs
+  var fs = options.fs || fsx;
   
   if (options.disableGlob || !glob.hasMagic(p))
     return afterGlob(null, [p])
@@ -264,7 +264,8 @@ function rimrafSync (p, options) {
   assert.equal(typeof options, 'object', 'rimraf: options should be object')
 
   var results
-
+  var fs = options.fs || fsx;
+  
   if (options.disableGlob || !glob.hasMagic(p)) {
     results = [p]
   } else {

--- a/rimraf.js
+++ b/rimraf.js
@@ -56,6 +56,8 @@ function rimraf (p, options, cb) {
   var errState = null
   var n = 0
 
+  if(options.fs) fs = options.fs
+  
   if (options.disableGlob || !glob.hasMagic(p))
     return afterGlob(null, [p])
 


### PR DESCRIPTION
Useful with `atom/electron` which use a [custom fs](https://github.com/atom/electron/blob/master/docs/tutorial/application-packaging.md) and you want to  pass the original `fs` as option to `rimraf`