### PR TITLE
Pass options to glob

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,16 @@ Install with `npm install rimraf`, or just drop rimraf.js somewhere.
 
 `rimraf(f, [opts], callback)`
 
-The first parameter will be interpreted as a globbing pattern for files. If you
-want to disable globbing you can do so with `opts.disableGlob` (defaults to
-`false`). This might be handy, for instance, if you have filenames that contain
-globbing wildcard characters.
+The first parameter will be interpreted as a globbing pattern for files. `opts`
+can include all [glob options](https://github.com/isaacs/node-glob#options) as
+well as:
+
+- `disableGlob`: Disables globbing. This might be handy if you have filenames
+  that contain globbing wildcard characters. Default: `false`.
+- `maxBusyTries`: How often to retry when encountering certain errors on the
+  Windows platform. Default: `3`.
+- `emfileWait`: The timeout in miliseconds between retries when encountering
+  a `EMFILE` error. Default: `1000`.
 
 The callback will be called with an error if there is one.  Certain
 errors are handled for you:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "bin": "./bin.js",
   "dependencies": {
-    "glob": "^5.0.14"
+    "glob": "^5.0.14",
+    "util-extend": "^1.0.1"
   },
   "files": [
     "LICENSE",

--- a/rimraf.js
+++ b/rimraf.js
@@ -5,6 +5,7 @@ var assert = require("assert")
 var path = require("path")
 var fs = require("fs")
 var glob = require("glob")
+var extend = require("util-extend")
 
 var globOpts = {
   nosort: true,
@@ -63,7 +64,7 @@ function rimraf (p, options, cb) {
     if (!er)
       return afterGlob(null, [p])
 
-    glob(p, globOpts, afterGlob)
+    glob(p, extend(globOpts, options), afterGlob)
   })
 
   function next (er) {
@@ -270,7 +271,7 @@ function rimrafSync (p, options) {
       fs.lstatSync(p)
       results = [p]
     } catch (er) {
-      results = glob.sync(p, globOpts)
+      results = glob.sync(p, extend(globOpts, options))
     }
   }
 


### PR DESCRIPTION
This change allows the user to pass down options to [`glob`](https://github.com/isaacs/node-glob) which is useful for my use case of cleaning up inside a directory including dotfiles which was previously not possile in a single run because there was no way to pass down the [`dot` option](https://github.com/isaacs/node-glob#options) to `glob`.

I also took the opportunity to document all valid options.