### PR TITLE
Fix tests so they will work correctly on windows

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -4,6 +4,19 @@ var t = require('tap')
 var fs = require('fs')
 var fill = require('./fill.js')
 
+t.test('Windows check', function (t) {
+	if (process.platform.match(/^win/)) {
+		var exec = require('child_process').spawnSync
+		var spawnedProc = exec('NET', [ 'SESSION' ])
+		if (spawnedProc.status) {
+			t.plan(0, 'Skip on Windows when not running as administrator')
+			process.exit()
+			return
+		}
+	}
+	t.end()
+})
+
 t.test('initial clean', function (t) {
   rimraf.sync(__dirname + '/target')
   t.throws(function () {

--- a/test/custom-fs.js
+++ b/test/custom-fs.js
@@ -156,8 +156,35 @@ function create () {
   })
 }
 
+function winMods() {
+	var objectsToMod = [expectAsync, expectSync]
+	
+	objectsToMod.forEach(function(elem) {
+		Object.keys(elem).forEach(function(key) {
+			if (elem[key].constructor.name === 'Array') {
+				for (var i=0, l=elem[key].length; i<l; i++) {
+					if (elem[key][i].indexOf('/') > -1) {
+						elem[key][i] = elem[key][i].replace(/\//g, '\\')
+					}
+				}
+			} else if (elem[key].constructor.name === 'Object') {
+				Object.keys(elem[key]).forEach(function(innerkey) {
+					if (innerkey.includes('/')) {
+						var newinnerkey = innerkey.replace(/\//g, '\\')
+						elem[key][newinnerkey] = elem[key][innerkey]
+						delete elem[key][innerkey]
+					}
+				})
+			}
+		})
+	})
+}
+
 t.test('setup', function (t) {
   create()
+  if (process.platform.match(/^win/)) {
+	  winMods()
+  }
   t.end()
 })
 


### PR DESCRIPTION
This is in reference to issue #112 

I've added a small check in basic.js so that the tests are skipped if not running as administrator on windows.

In custom-fs.js I modified the test to change the expected result to use the backslash directory separator if running on windows.