### PR TITLE
EBUSY should be also handled in other environments

### DIFF
--- a/rimraf.js
+++ b/rimraf.js
@@ -85,7 +85,7 @@ function rimraf (p, options, cb) {
     results.forEach(function (p) {
       rimraf_(p, options, function CB (er) {
         if (er) {
-          if (isWindows && (er.code === "EBUSY" || er.code === "ENOTEMPTY" || er.code === "EPERM") &&
+          if ((er.code === "EBUSY" || er.code === "ENOTEMPTY" || er.code === "EPERM") &&
               busyTries < options.maxBusyTries) {
             busyTries ++
             var time = busyTries * 100


### PR DESCRIPTION
I just removed "isWindows &&" and tested with "npm test".
And I checked up the change worked in my smart os environment.
Thank you.