### PR TITLE
Add a failure test case when `glob.cwd` is provided, and fix it

### DIFF
--- a/rimraf.js
+++ b/rimraf.js
@@ -38,6 +38,7 @@ function defaults (options) {
   }
   options.disableGlob = options.disableGlob || false
   options.glob = options.glob || defaultGlobOpts
+  options.glob.absolute = true
 }
 
 function rimraf (p, options, cb) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -38,7 +38,7 @@ t.test('async removal', function (t) {
 })
 
 t.test('glob', function (t) {
-  t.plan(2)
+  t.plan(3)
   t.test('async', function (t) {
     fill()
     var glob = require('glob')
@@ -62,6 +62,23 @@ t.test('glob', function (t) {
     t.notEqual(before.length, 0)
     rimraf.sync(pattern)
     var after = glob.sync(pattern)
+    t.same(after, [])
+    rimraf.sync(__dirname + '/target')
+    t.end()
+  })
+  t.test('modified cwd', function (t) {
+    fill()
+    var glob = require('glob')
+    var pattern = 'target/f-*'
+    var globOpts = {
+      cwd: __dirname
+    }
+    var before = glob.sync(pattern, globOpts)
+    t.notEqual(before.length, 0)
+    rimraf.sync(pattern, {
+      glob: globOpts
+    })
+    var after = glob.sync(pattern, globOpts)
     t.same(after, [])
     rimraf.sync(__dirname + '/target')
     t.end()


### PR DESCRIPTION
Because [node-glob](https://github.com/isaacs/node-glob) passes relative paths to [the callback](https://github.com/isaacs/rimraf/blob/5ecd3212b997eeb7d675a1a8d531e5bf3aa408bd/rimraf.js#L77) by default, currently `rimraf` tries to remove unexpected files and directories if `cwd` path for the glob pattern is modified.

Forcing node-glob's `absolute` option to be `true` fixes this problem.
