### PR TITLE
Retry only in case of an exception

### DIFF
--- a/rimraf.js
+++ b/rimraf.js
@@ -355,7 +355,7 @@ function rmkidsSync (p, options) {
     } catch(e) {
       if (++i < retries)
         continue
-      throw e;
+      throw e
     }
   } while (true)
 }

--- a/rimraf.js
+++ b/rimraf.js
@@ -352,9 +352,10 @@ function rmkidsSync (p, options) {
   do {
     try {
       return options.rmdirSync(p, options)
-    } finally {
+    } catch(e) {
       if (++i < retries)
         continue
+      throw e;
     }
   } while (true)
 }


### PR DESCRIPTION
The old impl retried even if the operation was successful, which causes an EPERM error.