### PR TITLE
Add a standalone script suitable for cleaning node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 npm-debug.log
 .nyc_output
 coverage
+bin-without-hashbang.js
+rimraf-standalone.js

--- a/README.md
+++ b/README.md
@@ -95,6 +95,38 @@ the async API.  It's better.
 If installed with `npm install rimraf -g` it can be used as a global
 command `rimraf <path> [<path> ...]` which is useful for cross platform support.
 
+## Standalone script for cleaning node_modules
+
+Many developers would like to use rimraf as part of a "clean" task which deletes
+all non-source control files in the project, including the node_modules
+directory. Unfortunately, this has two major downsides:
+
+* Must `npm install` to have rimraf available for cleaning.
+* On some platforms (possibland possibly other platforms) this fails,
+  because the execution of rimraf keeps files open/locked in the
+  node_modules directory.
+
+One workaround is to perform a global install is described above, but that
+violates the principle of a package including any needed development libraries
+in devDependencies, and breaks if rimraf is installed **both** globally and in
+the project.
+
+For a more comprehensive workaround, rimraf includes an extra file
+`rimraf-standalone.js` which you can copy to the root of your project, commit in
+your project, and set up a package script:
+
+```
+  "scripts": {
+    "clean": "node rimraf-standalone.js node_modules"
+  },
+```
+
+To clean:
+
+```
+npm run clean
+```
+
 ## mkdirp
 
 If you need to create a directory recursively, check out

--- a/package.json
+++ b/package.json
@@ -7,7 +7,12 @@
   "license": "ISC",
   "repository": "git://github.com/isaacs/rimraf.git",
   "scripts": {
-    "test": "tap test/*.js"
+    "test": "tap test/*.js",
+    "copy-bin": "cpy bin.js --rename=bin-without-hashbang.js .",
+    "patch-bin": "search-and-replace bin-without-hashbang.js . \"#!/usr/bin/env\" //removed",
+    "rollup": "rollup -c",
+    "build": "run-s copy-bin patch-bin rollup",
+    "clean-me": "node rimraf-standalone.js node_modules"
   },
   "bin": "./bin.js",
   "dependencies": {
@@ -17,10 +22,17 @@
     "LICENSE",
     "README.md",
     "bin.js",
-    "rimraf.js"
+    "rimraf.js",
+    "rimraf-standalone.js"
   ],
   "devDependencies": {
+    "cpy-cli": "^1.0.1",
     "mkdirp": "^0.5.1",
+    "npm-run-all": "^4.0.2",
+    "rollup": "^0.41.4",
+    "rollup-plugin-commonjs": "^7.0.0",
+    "rollup-plugin-node-resolve": "^2.0.0",
+    "search-and-replace": "^0.0.2",
     "tap": "^10.1.2"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,23 @@
+import nodeResolve from 'rollup-plugin-node-resolve';
+import commonjs from 'rollup-plugin-commonjs';
+
+export default {
+  entry: 'bin-without-hashbang.js', // entry point for the application
+  dest: 'rimraf-standalone.js',
+  useStrict: false,
+  format: 'cjs',
+  external: [
+    'assert',
+    'events',
+    'fs',
+    'path',
+    'util'
+  ],
+  plugins: [
+    nodeResolve(),
+    commonjs({
+      include: [
+      ]
+    })
+  ]
+}


### PR DESCRIPTION
This is a workaround/solution for annoying problems:

* Unlike almost every other package, I would really really like to be able to use rimraf from package scripts prior to a successful installation/population of node_modules

* I would like to be able to use rimraf to delete node_modules itself, in its entirety, on Windows, without relying on a global rimraf installation

I think it fixes #102.

It may make more sense for me to just publish this somewhere else, @isaacs please feel free to unceremoniously close my PR if you disagree with the whole approach taken here!



