### PR TITLE
Prevent callback from being called twice

### DIFF
--- a/rimraf.js
+++ b/rimraf.js
@@ -137,7 +137,7 @@ function rimraf_ (p, options, cb) {
 
     // Windows can EPERM on stat.  Life is suffering.
     if (er && er.code === "EPERM" && isWindows)
-      fixWinEPERM(p, options, er, cb)
+      return fixWinEPERM(p, options, er, cb)
 
     if (st && st.isDirectory())
       return rmdir(p, options, er, cb)


### PR DESCRIPTION
I'm one of the maintainers of `fs-extra`. At `fs-extra` we maintain a fork of rimraf internally. A user reported a bug in rimraf; I applied a patch to our fork, and I'm forwarding the patch upstream.

Here is the issue discussion: https://github.com/jprichardson/node-fs-extra/issues/392