### PR TITLE
add --maxBusyTries=n option to CLI

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -5,6 +5,7 @@ var rimraf = require('./')
 var help = false
 var dashdash = false
 var noglob = false
+var maxBusyTries = -1
 var args = process.argv.slice(2).filter(function(arg) {
   if (dashdash)
     return !!arg
@@ -16,6 +17,8 @@ var args = process.argv.slice(2).filter(function(arg) {
     noglob = false
   else if (arg.match(/^(-+|\/)(h(elp)?|\?)$/))
     help = true
+  else if (arg.startsWith('--maxBusyTries='))
+    maxBusyTries = arg.split('=')[1]
   else
     return !!arg
 })
@@ -32,6 +35,7 @@ if (help || args.length === 0) {
   log('  -h, --help     Display this usage info')
   log('  -G, --no-glob  Do not expand glob patterns in arguments')
   log('  -g, --glob     Expand glob patterns in arguments (default)')
+  log('  --maxBusyTries=<n> Retry on EBUSY,ENOEMPTY, or EPERM up to n times (on Windows systems)')
   process.exit(help ? 0 : 1)
 } else
   go(0)
@@ -42,6 +46,8 @@ function go (n) {
   var options = {}
   if (noglob)
     options = { glob: false }
+  if (maxBusyTries>=0)
+    Object.assign(options, { maxBusyTries: maxBusyTries })
   rimraf(args[n], options, function (er) {
     if (er)
       throw er


### PR DESCRIPTION
to help usage of CLI version on windows machines where the default of 3 retries is not enough, this adds --maxBusyTries=n to the CLI args to allow user to set this to desired value.