### PR TITLE
add node versions and allow failure for 0.10 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,10 @@ node_js:
   - '4'
   - '5'
   - '6'
+  - '7'
+  - '8'
+matrix:
+   fast_finish: true
+   allow_failures:
+     - node_js: '0.10'
+     - node_js: '0.12'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ node_js:
   - '7'
   - '8'
   - '9'
+  - '10'
 matrix:
    fast_finish: true
    allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ node_js:
   - '6'
   - '7'
   - '8'
+  - '9'
 matrix:
    fast_finish: true
    allow_failures:


### PR DESCRIPTION
Currently, build is failing because of SyntaxError: Use of const in strict mode.