### PR TITLE
add promise support with tests

### DIFF
--- a/rimraf.js
+++ b/rimraf.js
@@ -47,6 +47,16 @@ function rimraf (p, options, cb) {
     options = {}
   }
 
+  if (typeof cb !== 'function') {
+    if (!options) options = {}
+    return new Promise(function (resolve, reject) {
+      rimraf(p, options, function (err, data) {
+        if (err) return reject(err)
+        return resolve(data)
+      })
+    })
+  }
+
   assert(p, 'rimraf: missing path')
   assert.equal(typeof p, 'string', 'rimraf: path should be a string')
   assert.equal(typeof cb, 'function', 'rimraf: callback function required')

--- a/test/promise.js
+++ b/test/promise.js
@@ -1,0 +1,45 @@
+var rimraf = require('../')
+var t = require('tap')
+
+var fs = require('fs')
+var fill = require('./fill.js')
+
+t.test('promise async removal', function (t) {
+  fill()
+  t.ok(fs.statSync(__dirname + '/target').isDirectory())
+
+  rimraf(__dirname + '/target')
+  .then(function () {
+    t.throws(function () {
+      fs.statSync(__dirname + '/target')
+    })
+    t.end()
+  })
+})
+
+t.test('promise no glob', function (t) {
+  t.plan(3)
+  fill()
+  var glob = require('glob')
+  var pattern = __dirname + '/target/f-*'
+  var before = glob.sync(pattern)
+  t.notEqual(before.length, 0)
+  rimraf(pattern, { disableGlob: true })
+  .then(function () {
+    var after = glob.sync(pattern)
+    t.same(after, before)
+    rimraf(__dirname + '/target')
+    .then(function () {
+      t.throws(function () {
+        fs.statSync(__dirname + '/target')
+      })
+    })
+  })
+  .catch(t.fail)
+})
+
+t.test('verify that cleanup happened', function (t) {
+  t.throws(fs.statSync.bind(fs, __dirname + '/../target'))
+  t.throws(fs.statSync.bind(fs, __dirname + '/target'))
+  t.end()
+})


### PR DESCRIPTION
Add promise support with tests.

If no callback is provided return a promise.

Maybe a breaking change in as much as the current version throws an error if the callback is omitted.
, however I think it would be nice to write `await rimraf(path)` without `util.promisify`