### PR TITLE
 feat: make it possible to omit glob dependency

### DIFF
--- a/rimraf.js
+++ b/rimraf.js
@@ -43,8 +43,7 @@ function defaults (options) {
     options.disableGlob = true
   }
   if (options.disableGlob !== true && glob === undefined) {
-    console.error('glob dependency not found, set `options.disableGlob = true` if intentional')
-    process.exit(1)
+    throw Error('glob dependency not found, set `options.disableGlob = true` if intentional')
   }
   options.disableGlob = options.disableGlob || false
   options.glob = options.glob || defaultGlobOpts

--- a/rimraf.js
+++ b/rimraf.js
@@ -41,8 +41,9 @@ function defaults (options) {
   options.emfileWait = options.emfileWait || 1000
   if (options.glob === false) {
     options.disableGlob = true
-  } else if (glob === undefined) {
-    console.error('glob dependency not found, set `options.glob = false` if intentional')
+  }
+  if (options.disableGlob !== true && glob === undefined) {
+    console.error('glob dependency not found, set `options.disableGlob = true` if intentional')
     process.exit(1)
   }
   options.disableGlob = options.disableGlob || false

--- a/rimraf.js
+++ b/rimraf.js
@@ -4,7 +4,12 @@ rimraf.sync = rimrafSync
 var assert = require("assert")
 var path = require("path")
 var fs = require("fs")
-var glob = require("glob")
+let glob = undefined
+try {
+  glob = require("glob")
+} catch (_err) {
+  // treat glob as optional.
+}
 var _0666 = parseInt('666', 8)
 
 var defaultGlobOpts = {
@@ -36,6 +41,9 @@ function defaults (options) {
   options.emfileWait = options.emfileWait || 1000
   if (options.glob === false) {
     options.disableGlob = true
+  } else if (glob === undefined) {
+    console.error('glob dependency not found, set `options.glob = false` if intentional')
+    process.exit(1)
   }
   options.disableGlob = options.disableGlob || false
   options.glob = options.glob || defaultGlobOpts


### PR DESCRIPTION
makes it possible to omit glob dependency, so that we can more easily vendor `rimraf` in Node.js (see https://github.com/nodejs/node/pull/28208).

This approach has been tested in Node.js, rimraf simply needs to be vendored in `deps/rimraf` and added to `node.gyp`.

CC: @iansu