### PR TITLE
fix: do not check errors with `instanceof`.

### DIFF
--- a/rimraf.js
+++ b/rimraf.js
@@ -165,7 +165,7 @@ const fixWinEPERM = (p, options, er, cb) => {
   assert(options)
   assert(typeof cb === 'function')
   if (er)
-    assert(er instanceof Error)
+    assert(er.stack)
 
   options.chmod(p, 0o666, er2 => {
     if (er2)
@@ -186,7 +186,7 @@ const fixWinEPERMSync = (p, options, er) => {
   assert(p)
   assert(options)
   if (er)
-    assert(er instanceof Error)
+    assert(er.stack)
 
   try {
     options.chmodSync(p, 0o666)
@@ -217,7 +217,7 @@ const rmdir = (p, options, originalEr, cb) => {
   assert(p)
   assert(options)
   if (originalEr)
-    assert(originalEr instanceof Error)
+    assert(originalEr.stack)
   assert(typeof cb === 'function')
 
   // try to rmdir first, and only readdir on ENOTEMPTY or EEXIST (SunOS)
@@ -324,7 +324,7 @@ const rmdirSync = (p, options, originalEr) => {
   assert(p)
   assert(options)
   if (originalEr)
-    assert(originalEr instanceof Error)
+    assert(originalEr.stack)
 
   try {
     options.rmdirSync(p)

--- a/rimraf.js
+++ b/rimraf.js
@@ -164,8 +164,6 @@ const fixWinEPERM = (p, options, er, cb) => {
   assert(p)
   assert(options)
   assert(typeof cb === 'function')
-  if (er)
-    assert(er.stack)
 
   options.chmod(p, 0o666, er2 => {
     if (er2)
@@ -185,8 +183,6 @@ const fixWinEPERM = (p, options, er, cb) => {
 const fixWinEPERMSync = (p, options, er) => {
   assert(p)
   assert(options)
-  if (er)
-    assert(er.stack)
 
   try {
     options.chmodSync(p, 0o666)
@@ -216,8 +212,6 @@ const fixWinEPERMSync = (p, options, er) => {
 const rmdir = (p, options, originalEr, cb) => {
   assert(p)
   assert(options)
-  if (originalEr)
-    assert(originalEr.stack)
   assert(typeof cb === 'function')
 
   // try to rmdir first, and only readdir on ENOTEMPTY or EEXIST (SunOS)
@@ -323,8 +317,6 @@ const rimrafSync = (p, options) => {
 const rmdirSync = (p, options, originalEr) => {
   assert(p)
   assert(options)
-  if (originalEr)
-    assert(originalEr.stack)
 
   try {
     options.rmdirSync(p)


### PR DESCRIPTION
It's probably safe enough to assume existance of the `.stack` property
on the Error object.

This should avoid the cross-VM type issues we see in Jest.

Fixes #208