### PR TITLE
docs(readme): Fix link to `mkdirp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,4 +98,4 @@ command `rimraf <path> [<path> ...]` which is useful for cross platform support.
 ## mkdirp
 
 If you need to create a directory recursively, check out
-[mkdirp](https://github.com/substack/node-mkdirp).
+[mkdirp](https://github.com/isaacs/node-mkdirp).


### PR DESCRIPTION
Points the link to isaacs' fork (original user/repo no longer exists and gives a 404)