### PR TITLE
fix: add types

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "main": "./dist/cjs/src/index.js",
   "module": "./dist/mjs/src/index.js",
   "bin": "./dist/cjs/src/bin.js",
+  "types": "./dist/cjs/src/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/cjs/src/index.d.ts",
       "import": "./dist/mjs/src/index.js",
       "require": "./dist/cjs/src/index.js"
     }

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,7 @@ t.same(
   require('../package.json').exports,
   {
     '.': {
+      types: './dist/cjs/src/index.d.ts',
       import: './dist/mjs/src/index.js',
       require: './dist/cjs/src/index.js',
     },


### PR DESCRIPTION
Add types to the package.

TypeScript need this to read the type definition.

btw, the ESM one likely using `module: Node16` should be the correct value, instead of `ESNext`.

But that can be a different PR.