### PR TITLE
refactor: switch to native `fs/promises`

### DIFF
--- a/src/fs.ts
+++ b/src/fs.ts
@@ -15,76 +15,22 @@ export {
 } from 'fs'
 
 import { readdirSync as rdSync } from 'fs'
+
+import fsPromises from 'fs/promises'
+
 export const readdirSync = (path: fs.PathLike): Dirent[] =>
   rdSync(path, { withFileTypes: true })
 
-// unrolled for better inlining, this seems to get better performance
-// than something like:
-// const makeCb = (res, rej) => (er, ...d) => er ? rej(er) : res(...d)
-// which would be a bit cleaner.
-
-const chmod = (path: fs.PathLike, mode: fs.Mode): Promise<void> =>
-  new Promise((res, rej) =>
-    fs.chmod(path, mode, (er, ...d: any[]) => (er ? rej(er) : res(...d)))
-  )
-
-const mkdir = (
-  path: fs.PathLike,
-  options?:
-    | fs.Mode
-    | (fs.MakeDirectoryOptions & { recursive?: boolean | null })
-    | undefined
-    | null
-): Promise<string | undefined> =>
-  new Promise((res, rej) =>
-    fs.mkdir(path, options, (er, made) => (er ? rej(er) : res(made)))
-  )
-
-const readdir = (path: fs.PathLike): Promise<Dirent[]> =>
-  new Promise<Dirent[]>((res, rej) =>
-    fs.readdir(path, { withFileTypes: true }, (er, data) =>
-      er ? rej(er) : res(data)
-    )
-  )
-
-const rename = (oldPath: fs.PathLike, newPath: fs.PathLike): Promise<void> =>
-  new Promise((res, rej) =>
-    fs.rename(oldPath, newPath, (er, ...d: any[]) => (er ? rej(er) : res(...d)))
-  )
-
-const rm = (path: fs.PathLike, options: fs.RmOptions): Promise<void> =>
-  new Promise((res, rej) =>
-    fs.rm(path, options, (er, ...d: any[]) => (er ? rej(er) : res(...d)))
-  )
-
-const rmdir = (path: fs.PathLike): Promise<void> =>
-  new Promise((res, rej) =>
-    fs.rmdir(path, (er, ...d: any[]) => (er ? rej(er) : res(...d)))
-  )
-
-const stat = (path: fs.PathLike): Promise<fs.Stats> =>
-  new Promise((res, rej) =>
-    fs.stat(path, (er, data) => (er ? rej(er) : res(data)))
-  )
-
-const lstat = (path: fs.PathLike): Promise<fs.Stats> =>
-  new Promise((res, rej) =>
-    fs.lstat(path, (er, data) => (er ? rej(er) : res(data)))
-  )
-
-const unlink = (path: fs.PathLike): Promise<void> =>
-  new Promise((res, rej) =>
-    fs.unlink(path, (er, ...d: any[]) => (er ? rej(er) : res(...d)))
-  )
-
 export const promises = {
-  chmod,
-  mkdir,
-  readdir,
-  rename,
-  rm,
-  rmdir,
-  stat,
-  lstat,
-  unlink,
+  chmod: fsPromises.chmod,
+  mkdir: fsPromises.mkdir,
+  readdir(path: fs.PathLike) {
+    return fsPromises.readdir(path, { withFileTypes: true })
+  },
+  rename: fsPromises.rename,
+  rm: fsPromises.rm,
+  rmdir: fsPromises.rmdir,
+  stat: fsPromises.stat,
+  lstat: fsPromises.lstat,
+  unlink: fsPromises.unlink,
 }


### PR DESCRIPTION
Replace home-baked promisfied `fs` methods with the native `fs/promises`.

`rimraf` is already targeting Node.js 14, and the `fs/promises` API has been available since Node.js 14.0.0:

<img width="631" alt="image" src="https://github.com/isaacs/rimraf/assets/40715044/9570f493-d7d6-4943-8b2e-d5f5fb3414ee">
