### PR TITLE
333: remove timers import

### DIFF
--- a/src/retry-busy.ts
+++ b/src/retry-busy.ts
@@ -1,6 +1,5 @@
 // note: max backoff is the maximum that any *single* backoff will do
 
-import { setTimeout } from 'timers/promises'
 import { RimrafAsyncOptions, RimrafOptions } from './index.js'
 import { isFsError } from './error.js'
 

--- a/test/integration/delete-many-files.ts
+++ b/test/integration/delete-many-files.ts
@@ -5,7 +5,6 @@ import { statSync, mkdirSync, readdirSync } from '../../src/fs.js'
 import { writeFileSync } from 'fs'
 import { resolve, dirname } from 'path'
 import { manual } from '../../src/index.js'
-import { setTimeout } from 'timers/promises'
 const cases = { manual }
 
 // run with RIMRAF_TEST_START_CHAR/_END_CHAR/_DEPTH environs to


### PR DESCRIPTION
fixes #333 to remove failing timers import. these imports are not needed since `setTimeout` is a built-in JS function