### PR TITLE
fix: update glob to v12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.1.0",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "glob": "^11.0.3",
+        "glob": "^12.0.0",
         "package-json-from-dist": "^1.0.1"
       },
       "bin": {
@@ -19,8 +19,8 @@
         "@types/node": "^24.9.2",
         "mkdirp": "^3.0.1",
         "prettier": "^3.6.2",
-        "tap": "^21.1.1",
-        "tshy": "^3.0.3",
+        "tap": "^21.1.4",
+        "tshy": "^3.1.0",
         "typedoc": "^0.28.14"
       },
       "engines": {
@@ -242,28 +242,21 @@
       }
     },
     "node_modules/@npmcli/agent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-3.0.0.tgz",
-      "integrity": "sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
+      "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "agent-base": "^7.1.0",
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.1",
-        "lru-cache": "^10.0.1",
+        "lru-cache": "^11.2.1",
         "socks-proxy-agent": "^8.0.3"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
-    },
-    "node_modules/@npmcli/agent/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/@npmcli/fs": {
       "version": "4.0.0",
@@ -279,20 +272,20 @@
       }
     },
     "node_modules/@npmcli/git": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-7.0.0.tgz",
-      "integrity": "sha512-vnz7BVGtOctJAIHouCJdvWBhsTVSICMeUgZo2c7XAi5d5Rrl80S1H7oPym7K03cRuinK5Q6s2dw36+PgXQTcMA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-7.0.1.tgz",
+      "integrity": "sha512-+XTFxK2jJF/EJJ5SoAzXk3qwIDfvFc5/g+bD274LZ7uY7LE8sTfG6Z8rOanPl2ZEvZWqNvmEdtXC25cE54VcoA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/promise-spawn": "^8.0.0",
-        "ini": "^5.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "ini": "^6.0.0",
         "lru-cache": "^11.2.1",
         "npm-pick-manifest": "^11.0.1",
-        "proc-log": "^5.0.0",
+        "proc-log": "^6.0.0",
         "promise-retry": "^2.0.1",
         "semver": "^7.3.5",
-        "which": "^5.0.0"
+        "which": "^6.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -309,9 +302,9 @@
       }
     },
     "node_modules/@npmcli/git/node_modules/which": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.0.tgz",
+      "integrity": "sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -321,24 +314,24 @@
         "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@npmcli/installed-package-contents": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-3.0.0.tgz",
-      "integrity": "sha512-fkxoPuFGvxyrH+OQzyTkX2LUEamrF4jZSmxjAtPPHHGO0dqsQ8tTKjnIS8SAnPHdk2I03BDtSMR5K/4loKg79Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-4.0.0.tgz",
+      "integrity": "sha512-yNyAdkBxB72gtZ4GrwXCM0ZUedo9nIbOMKfGjt6Cu6DXf0p8y1PViZAKDC8q8kv/fufx0WTjRBdSlyrvnP7hmA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "npm-bundled": "^4.0.0",
-        "npm-normalize-package-bin": "^4.0.0"
+        "npm-bundled": "^5.0.0",
+        "npm-normalize-package-bin": "^5.0.0"
       },
       "bin": {
         "installed-package-contents": "bin/index.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@npmcli/node-gyp": {
@@ -352,17 +345,17 @@
       }
     },
     "node_modules/@npmcli/package-json": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-7.0.1.tgz",
-      "integrity": "sha512-956YUeI0YITbk2+KnirCkD19HLzES0habV+Els+dyZaVsaM6VGSiNwnRu6t3CZaqDLz4KXy2zx+0N/Zy6YjlAA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-7.0.2.tgz",
+      "integrity": "sha512-0ylN3U5htO1SJTmy2YI78PZZjLkKUGg7EKgukb2CRi0kzyoDr0cfjHAzi7kozVhj2V3SxN1oyKqZ2NSo40z00g==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/git": "^7.0.0",
         "glob": "^11.0.3",
         "hosted-git-info": "^9.0.0",
-        "json-parse-even-better-errors": "^4.0.0",
-        "proc-log": "^5.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.5.3",
         "validate-npm-package-license": "^3.0.4"
       },
@@ -370,17 +363,57 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/@npmcli/package-json/node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/minimatch": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@npmcli/promise-spawn": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-8.0.3.tgz",
-      "integrity": "sha512-Yb00SWaL4F8w+K8YGhQ55+xE4RUNdMHV43WZGsiTM92gS+lC0mGsn7I4hLug7pbao035S6bj3Y3w0cUNGLfmkg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-9.0.1.tgz",
+      "integrity": "sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "which": "^5.0.0"
+        "which": "^6.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@npmcli/promise-spawn/node_modules/isexe": {
@@ -394,9 +427,9 @@
       }
     },
     "node_modules/@npmcli/promise-spawn/node_modules/which": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.0.tgz",
+      "integrity": "sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -406,45 +439,32 @@
         "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@npmcli/redact": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-3.2.2.tgz",
-      "integrity": "sha512-7VmYAmk4csGv08QzrDKScdzn11jHPFGyqJW39FyPgPuAp3zIaUmuCo1yxw9aGs+NEJuTGQ9Gwqpt93vtJubucg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
+      "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@npmcli/run-script": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-10.0.2.tgz",
-      "integrity": "sha512-9lCTqxaoa9c9cdkzSSx+q/qaYrCrUPEwTWzLkVYg1/T8ESH3BG9vmb1zRc6ODsBVB0+gnGRSqSr01pxTS1yX3A==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-10.0.3.tgz",
+      "integrity": "sha512-ER2N6itRkzWbbtVmZ9WKaWxVlKlOeBFF1/7xx+KA5J1xKa4JjUwBdb6tDpk0v1qA+d+VDwHI9qmLcXSWcmi+Rw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/node-gyp": "^5.0.0",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/promise-spawn": "^9.0.0",
-        "node-gyp": "^11.0.0",
+        "node-gyp": "^12.1.0",
         "proc-log": "^6.0.0",
-        "which": "^5.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@npmcli/run-script/node_modules/@npmcli/promise-spawn": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-9.0.0.tgz",
-      "integrity": "sha512-qxvGj3ZM6Zuk8YeVMY0gZHY19WN6g3OGxwR4MBaxHImfD/4zD0HpgBHNOSayEaisj/p3PyQjdQlO9tbl5ZBFZg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "which": "^5.0.0"
+        "which": "^6.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -460,20 +480,10 @@
         "node": ">=16"
       }
     },
-    "node_modules/@npmcli/run-script/node_modules/proc-log": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.0.0.tgz",
-      "integrity": "sha512-KG/XsTDN901PNfPfAMmj6N/Ywg9tM+bHK8pAz+27fS4N4Pcr+4zoYBOcGSBu6ceXYNPxkLpa4ohtfxV1XcLAfA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/@npmcli/run-script/node_modules/which": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.0.tgz",
+      "integrity": "sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -483,7 +493,7 @@
         "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -597,44 +607,14 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@sigstore/sign/node_modules/@npmcli/agent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
-      "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
+    "node_modules/@sigstore/sign/node_modules/proc-log": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
+      "integrity": "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==",
       "dev": true,
       "license": "ISC",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.1",
-        "lru-cache": "^11.2.1",
-        "socks-proxy-agent": "^8.0.3"
-      },
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@sigstore/sign/node_modules/make-fetch-happen": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.2.tgz",
-      "integrity": "sha512-sI1NY4lWlXBAfjmCtVWIIpBypbBdhHtcjnwnv+gtCnsaOffyFil3aidszGC8hgzJe+fT1qix05sWxmD/Bmf/oQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/agent": "^4.0.0",
-        "cacache": "^20.0.1",
-        "http-cache-semantics": "^4.1.1",
-        "minipass": "^7.0.2",
-        "minipass-fetch": "^4.0.0",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^1.0.0",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
-        "ssri": "^12.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@sigstore/tuf": {
@@ -667,9 +647,9 @@
       }
     },
     "node_modules/@tapjs/after": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@tapjs/after/-/after-3.0.2.tgz",
-      "integrity": "sha512-Xb0bqJWXfp6VVSx1T96lNJM67v2XxJCG3o7mH77weB+RzwAuf0uzGYy/hxP+nUAWh9yH+lHzuHclL+DR8Zlu3Q==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@tapjs/after/-/after-3.0.5.tgz",
+      "integrity": "sha512-pGpNAB+TCNjSi2fxMre1BGhkxvWien89Zl+lXM5ZI7zjcC/0+M5zbWoaGCGS923jnijG9WUwRsfU/INZhWVqMQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -679,13 +659,13 @@
         "node": "20 || >=22"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.0.2"
+        "@tapjs/core": "4.0.5"
       }
     },
     "node_modules/@tapjs/after-each": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@tapjs/after-each/-/after-each-4.0.2.tgz",
-      "integrity": "sha512-OQEENy55qtJ7WaMnIQvf0YaV4/YjI2B9+ezn679Vrptg/xMbaG5fSJz/Z5BFroh05HiWRo+MGu66q7Lb00kDJg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@tapjs/after-each/-/after-each-4.0.5.tgz",
+      "integrity": "sha512-eYBlEv6Et9apLoYDYmGFqPgFctK2L5ENLFMqgt1hugON8SHSpKcM3BQEBdpy33oovOTlODiQy5LL6jswUod8nQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -695,19 +675,19 @@
         "node": "20 || >=22"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.0.2"
+        "@tapjs/core": "4.0.5"
       }
     },
     "node_modules/@tapjs/asserts": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@tapjs/asserts/-/asserts-4.0.2.tgz",
-      "integrity": "sha512-XeAYvYMu61/Gc9Dpn+0QZCjUTbbQE7DckiZNhQNMuMwAXUDEZR/TbxJNysIdMWq2ag75TQQ6ylCUJovy7HPDlg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@tapjs/asserts/-/asserts-4.0.5.tgz",
+      "integrity": "sha512-cS4nHCl2FmFjJI11eVMB1pOFnJcrMghUBDqdKcu0foVAt/eVQo71r6lFzyG6jTFm3Pvlkl23fwn6jzQT1ECt3w==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@tapjs/stack": "4.0.1",
+        "@tapjs/stack": "4.0.2",
         "is-actual-promise": "^1.0.1",
-        "tcompare": "9.0.1",
+        "tcompare": "9.0.2",
         "trivial-deferred": "^2.0.0"
       },
       "engines": {
@@ -717,13 +697,13 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.0.2"
+        "@tapjs/core": "4.0.5"
       }
     },
     "node_modules/@tapjs/before": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@tapjs/before/-/before-4.0.2.tgz",
-      "integrity": "sha512-ODi0rXOqCWZLS1j6fJ2iyqaXy6B/y75x8Y940hRAe0DfPPf48IgZY84+GfWWVIkRqmbYZS/F0rwcegPHxI/xHg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@tapjs/before/-/before-4.0.5.tgz",
+      "integrity": "sha512-1WOAGpYKxtFNWi1cf/BGXC2IqawNjV10FHvHZKllfLOUjtxfLYLvwnaRoqntILbc/SZeiFCXqSpWtaX/HzKYqg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -733,13 +713,13 @@
         "node": "20 || >=22"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.0.2"
+        "@tapjs/core": "4.0.5"
       }
     },
     "node_modules/@tapjs/before-each": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@tapjs/before-each/-/before-each-4.0.2.tgz",
-      "integrity": "sha512-CXNWJ/pvqu3DwNjgnOX9zfmxYz7OvxQ4w7X/1uyFUblWarYYOUqtLsF/FrBHn3rqOowNtP5KJAzY9Wx5UT3r+g==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@tapjs/before-each/-/before-each-4.0.5.tgz",
+      "integrity": "sha512-wTRL98Th/wODIexDYVyAZVJ110JQAI6lVTyULKutSYCQ4JDk+CPYMwA6RQPO6JGIqP7GX8QlUo+2ZAWo9Y9iYg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -749,35 +729,35 @@
         "node": "20 || >=22"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.0.2"
+        "@tapjs/core": "4.0.5"
       }
     },
     "node_modules/@tapjs/chdir": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@tapjs/chdir/-/chdir-3.0.2.tgz",
-      "integrity": "sha512-KYDxkkzGeEhAT33VDWqIx8FRLk+cOzVsj/E0JBRd45n18EHT7C/wE/Nqhu+843nVhABp/c5BZMb+Rib/fCQV1g==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@tapjs/chdir/-/chdir-3.0.5.tgz",
+      "integrity": "sha512-VzlCGIi8s4flaCraMFY2Q0105bz6UV/FCT9pNeVh/2otrrLy9Z7QbP7+kdzQ+sYlgKbN4uuPVn7AfF9YX9DMMw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.0.2"
+        "@tapjs/core": "4.0.5"
       }
     },
     "node_modules/@tapjs/config": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@tapjs/config/-/config-5.0.2.tgz",
-      "integrity": "sha512-VfvYwcRGC3fbBAuRZs8VheA4YTa1CaJlYonHM2YM1Uu+UGeLCmvxJjIOBauhtp+F/QczUsJxqOjDy9z9ny1UYQ==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@tapjs/config/-/config-5.0.5.tgz",
+      "integrity": "sha512-jTUn3y9F1Da0oGW2rZHmFZsReXNv0dhif2rzzeWdKUJ4op+vb1iduJ0mdY4Nd+tcIxG5FVBcmQp7tVUTXjqvJQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@tapjs/core": "4.0.2",
-        "@tapjs/test": "4.0.2",
+        "@tapjs/core": "4.0.5",
+        "@tapjs/test": "4.0.5",
         "chalk": "^5.6.2",
         "jackspeak": "^4.0.1",
         "polite-json": "^5.0.0",
-        "tap-yaml": "4.0.1",
+        "tap-yaml": "4.0.2",
         "walk-up-path": "^4.0.0"
       },
       "engines": {
@@ -787,28 +767,29 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.0.2",
-        "@tapjs/test": "4.0.2"
+        "@tapjs/core": "4.0.5",
+        "@tapjs/test": "4.0.5"
       }
     },
     "node_modules/@tapjs/core": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@tapjs/core/-/core-4.0.2.tgz",
-      "integrity": "sha512-kzM90qsqHAJOTUMVjB3G26c3Ka4/HFg253lSt3pxBFesIHneIZe6Fre1NEWnHZPLmmzBO6HRRffc9zDxXcaeRw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@tapjs/core/-/core-4.0.5.tgz",
+      "integrity": "sha512-+hbz459mNlgWZsf917+6h0uioJfVRh7ZHJYTn5a+oFV5wS9JxUlCexcw4QlXZHf0UBI36ownOtcjXAmcAqbYiw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "@tapjs/processinfo": "^3.1.8",
-        "@tapjs/stack": "4.0.1",
-        "@tapjs/test": "4.0.2",
+        "@tapjs/stack": "4.0.2",
+        "@tapjs/test": "4.0.5",
         "async-hook-domain": "^4.0.1",
         "diff": "^8.0.2",
         "is-actual-promise": "^1.0.1",
         "minipass": "^7.0.4",
         "signal-exit": "4.1",
-        "tap-parser": "18.0.1",
-        "tap-yaml": "4.0.1",
-        "tcompare": "9.0.1",
+        "tap-parser": "18.0.2",
+        "tap-yaml": "4.0.2",
+        "tcompare": "9.0.2",
         "trivial-deferred": "^2.0.0"
       },
       "engines": {
@@ -816,9 +797,9 @@
       }
     },
     "node_modules/@tapjs/error-serdes": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@tapjs/error-serdes/-/error-serdes-4.0.1.tgz",
-      "integrity": "sha512-8GiOXbgGIRBcSGnPXYuiboy0xJQDMP2OcILnghHX/jzJKi2l9mxX6FTonOWj/0qsf5Ji5Z4/DIKRcYINIxaejg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@tapjs/error-serdes/-/error-serdes-4.0.2.tgz",
+      "integrity": "sha512-FQJef2VbahgxCVDQGHPBtjZ0zbrgwXAO1Nxh0pbCUfbp5ZkEl1+IBW9uiiiFC7cdEv8n48l+bYz7PQh9RMRg6g==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -832,9 +813,9 @@
       }
     },
     "node_modules/@tapjs/filter": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@tapjs/filter/-/filter-4.0.2.tgz",
-      "integrity": "sha512-Pfi1u1naoUL4G4AoJOUEUQauaZeF4gGk8MZ8It2ht60gopYsxy9sSmIKlKPvZm13f110pZxJfO+hogappAmDfw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@tapjs/filter/-/filter-4.0.5.tgz",
+      "integrity": "sha512-4DcaRJROM7VF6MRYHvZ8LkRo7R81DUHfrMpgtLXrRa3XG3Ose7vFMw4IJWfusADoA+futJ4dqZl1XH3iLPO2rA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -844,13 +825,13 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.0.2"
+        "@tapjs/core": "4.0.5"
       }
     },
     "node_modules/@tapjs/fixture": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@tapjs/fixture/-/fixture-4.0.2.tgz",
-      "integrity": "sha512-h161PA9ngT3zG6iLybAUlrSWx31OFx7Av1aR4FHvui9IkseXaF0x6gxS0MMaXwdyRYrD7lFvmU7SRTDlvvdeBA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@tapjs/fixture/-/fixture-4.0.5.tgz",
+      "integrity": "sha512-9c9Kk1QMr5o5qHjOtRvwYI2JB6pvy1ksLKC4KnTGEno6oxtDabXuZ7hVAValBB7PjmVEgDsg3DFoMJnVX2Gpaw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -864,35 +845,35 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.0.2"
+        "@tapjs/core": "4.0.5"
       }
     },
     "node_modules/@tapjs/intercept": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@tapjs/intercept/-/intercept-4.0.2.tgz",
-      "integrity": "sha512-rlZcO/Yf9vU8ypfQEO0c/QUCcGCr0IMJltg53805ILuNhTDR7x0vlJSvJ7fLsuoezkUwXlWdlED6ZqIID7RokA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@tapjs/intercept/-/intercept-4.0.5.tgz",
+      "integrity": "sha512-6fcN2XnApXJw+2rUwNTdipLuf9ZCe9A9QWzGpNYAXVHJwdGZ38Vpto1P4CzXa55I9MonaBFHGDZwXCtKFRgt3g==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@tapjs/after": "3.0.2",
-        "@tapjs/stack": "4.0.1"
+        "@tapjs/after": "3.0.5",
+        "@tapjs/stack": "4.0.2"
       },
       "engines": {
         "node": "20 || >=22"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.0.2"
+        "@tapjs/core": "4.0.5"
       }
     },
     "node_modules/@tapjs/mock": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@tapjs/mock/-/mock-4.0.2.tgz",
-      "integrity": "sha512-48o3xz3Xl83Ei25KOR5aWytbCYUl33GQAoQm4khFpTyI/v3fjyR9jDgFLAT7IWix8tRrrkMf+PynmZkWVQ4oKA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@tapjs/mock/-/mock-4.0.5.tgz",
+      "integrity": "sha512-0hiGBF+oAgUf2OEoNc7A8toSYi75Pmqfkrlo4eNxnRWGMGeTw70JADDbSqypSxiVOEqgT2zoQUWNR0VOcWj18g==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@tapjs/after": "3.0.2",
-        "@tapjs/stack": "4.0.1",
+        "@tapjs/after": "3.0.5",
+        "@tapjs/stack": "4.0.2",
         "resolve-import": "^2.0.0",
         "walk-up-path": "^4.0.0"
       },
@@ -903,19 +884,19 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.0.2"
+        "@tapjs/core": "4.0.5"
       }
     },
     "node_modules/@tapjs/node-serialize": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@tapjs/node-serialize/-/node-serialize-4.0.2.tgz",
-      "integrity": "sha512-oparVnZqbwF7O7IQn4nfpnsddtmlkWPB033uzZbvSW6v0U6T8DBENgKAfzJ2sNQH3f2Xaa3dqK+N5brwQa3P2g==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@tapjs/node-serialize/-/node-serialize-4.0.5.tgz",
+      "integrity": "sha512-+12IqvayivKYSkHs1d/Z5PCLaK8PbV2lo/w6FKGxsBwWh79ZEksuW+sRaohMQ0zHGLjzFOMMETz8o2vvVuGBBQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@tapjs/error-serdes": "4.0.1",
-        "@tapjs/stack": "4.0.1",
-        "tap-parser": "18.0.1"
+        "@tapjs/error-serdes": "4.0.2",
+        "@tapjs/stack": "4.0.2",
+        "tap-parser": "18.0.2"
       },
       "engines": {
         "node": "20 || >=22"
@@ -924,7 +905,7 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.0.2"
+        "@tapjs/core": "4.0.5"
       }
     },
     "node_modules/@tapjs/processinfo": {
@@ -944,14 +925,14 @@
       }
     },
     "node_modules/@tapjs/reporter": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@tapjs/reporter/-/reporter-4.0.3.tgz",
-      "integrity": "sha512-Mdx3+C3f4q3llawja5V2RVIfFzr1KhEm57i9xUJTgM5kHcPjrMw14aQUCwYxLSYSd5esOubnnV5lD9rxQb+tyQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@tapjs/reporter/-/reporter-4.0.6.tgz",
+      "integrity": "sha512-1UsAFpdLXHBDuFEyPx3SeKDsvWYOHi/Ds4kFM+szVRmE01/CxE3zbUoDq5VvCjRxG4PgE25FOdwSEtSQ0+6n+Q==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@tapjs/config": "5.0.2",
-        "@tapjs/stack": "4.0.1",
+        "@tapjs/config": "5.0.5",
+        "@tapjs/stack": "4.0.2",
         "chalk": "^5.6.2",
         "ink": "^5.2.1",
         "minipass": "^7.0.4",
@@ -960,9 +941,9 @@
         "prismjs-terminal": "^1.2.3",
         "react": "^18.2.0",
         "string-length": "^6.0.0",
-        "tap-parser": "18.0.1",
-        "tap-yaml": "4.0.1",
-        "tcompare": "9.0.1"
+        "tap-parser": "18.0.2",
+        "tap-yaml": "4.0.2",
+        "tcompare": "9.0.2"
       },
       "engines": {
         "node": "20 || >=22"
@@ -971,29 +952,29 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.0.2"
+        "@tapjs/core": "4.0.5"
       }
     },
     "node_modules/@tapjs/run": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@tapjs/run/-/run-4.0.3.tgz",
-      "integrity": "sha512-kkoMk5OJPgxigZZwu47ix2Zo8U64t8YiFiz+Iec5HrSW1BNgQyhurfMbc8uGjBHh3OhvJBaWhWuzctn0ROJrEQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@tapjs/run/-/run-4.0.6.tgz",
+      "integrity": "sha512-+C+R1zpau/STqd5qu1ekXQYLrb0xRh+b8XoTBIhGp/OtCNqjP7xN+QWJ5Tf0srB/0GS0eMSMjHVMDVVGISEG2A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@tapjs/after": "3.0.2",
-        "@tapjs/before": "4.0.2",
-        "@tapjs/config": "5.0.2",
+        "@tapjs/after": "3.0.5",
+        "@tapjs/before": "4.0.5",
+        "@tapjs/config": "5.0.5",
         "@tapjs/processinfo": "^3.1.8",
-        "@tapjs/reporter": "4.0.3",
-        "@tapjs/spawn": "4.0.2",
-        "@tapjs/stdin": "4.0.2",
-        "@tapjs/test": "4.0.2",
+        "@tapjs/reporter": "4.0.6",
+        "@tapjs/spawn": "4.0.5",
+        "@tapjs/stdin": "4.0.5",
+        "@tapjs/test": "4.0.5",
         "c8": "^10.1.3",
         "chalk": "^5.6.2",
         "chokidar": "^4.0.2",
         "foreground-child": "^3.1.1",
-        "glob": "^11.0.0",
+        "glob": "^12.0.0",
         "minipass": "^7.0.4",
         "mkdirp": "^3.0.1",
         "opener": "^1.5.2",
@@ -1003,9 +984,9 @@
         "rimraf": "^6.0.0",
         "semver": "^7.7.2",
         "signal-exit": "^4.1.0",
-        "tap-parser": "18.0.1",
-        "tap-yaml": "4.0.1",
-        "tcompare": "9.0.1",
+        "tap-parser": "18.0.2",
+        "tap-yaml": "4.0.2",
+        "tcompare": "9.0.2",
         "trivial-deferred": "^2.0.0",
         "which": "^5.0.0"
       },
@@ -1019,7 +1000,7 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.0.2"
+        "@tapjs/core": "4.0.5"
       }
     },
     "node_modules/@tapjs/run/node_modules/isexe": {
@@ -1049,14 +1030,14 @@
       }
     },
     "node_modules/@tapjs/snapshot": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@tapjs/snapshot/-/snapshot-4.0.2.tgz",
-      "integrity": "sha512-PWlWNEH+4x0oN8nemk+2rk3jub2L/7c6A383SD15GadGOT4hYvckqY2mCZarMAoV5xErFZOglGTD9do83TWMPQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@tapjs/snapshot/-/snapshot-4.0.5.tgz",
+      "integrity": "sha512-+sINdNe7+OSQ72pukztnmmDgVDyVC5rVe48BkQlcd3/PUq/vkowvOdmYWOd7XAYkFhyk0luhmv/fAlSSrRvxCA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "is-actual-promise": "^1.0.1",
-        "tcompare": "9.0.1",
+        "tcompare": "9.0.2",
         "trivial-deferred": "^2.0.0"
       },
       "engines": {
@@ -1066,26 +1047,26 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.0.2"
+        "@tapjs/core": "4.0.5"
       }
     },
     "node_modules/@tapjs/spawn": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@tapjs/spawn/-/spawn-4.0.2.tgz",
-      "integrity": "sha512-CNOrZFXh+mm2iul/cGRgVA4HMv9GxmtbgQSICMjRrj8VLDzMboW862P+wEvfYrHeXdCGAGWKqTIcsX5pXQVQRA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@tapjs/spawn/-/spawn-4.0.5.tgz",
+      "integrity": "sha512-wJ08kjgjSP5jb30ccj1u1IpVCpRS1kNjl50ZA220gxDEVFbPbohOIkFYlrOJrylEkuXcmPwOnEhvfzTqoXfqHg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.0.2"
+        "@tapjs/core": "4.0.5"
       }
     },
     "node_modules/@tapjs/stack": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@tapjs/stack/-/stack-4.0.1.tgz",
-      "integrity": "sha512-Rbyz4XMuZWNxCs+/j0c5idFz4MKBo7uSaNvk6R7Al9jQJzk7Lv0WC2lWW0CV+7t/TUynTFxEwAaY5pIM752WQg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@tapjs/stack/-/stack-4.0.2.tgz",
+      "integrity": "sha512-ZqazlvRWjOAnIL/Cx8aVY+YOJmZL8tTS4lwG91LtJp8lt+/2Rl5nuFrydqaO4G2pvujtOaC9fuNq4/8rQ9OtDQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -1096,50 +1077,50 @@
       }
     },
     "node_modules/@tapjs/stdin": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@tapjs/stdin/-/stdin-4.0.2.tgz",
-      "integrity": "sha512-6e/jQ0I9G6DC9m6Yj3jC6sNAmiwvrPVni3iMpJn3GICs0dROyx1m9wnMBK5wgKNgN2AXfvEOtf5Cby124eHeJQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@tapjs/stdin/-/stdin-4.0.5.tgz",
+      "integrity": "sha512-jCHFngS1Oi3ntT7LS6KAeTkoy/bAuj6TaCL5oPu7N0mO5+itoAcLTw+385KczOK7wfU3PNNoXZePMrbkr3EpxA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.0.2"
+        "@tapjs/core": "4.0.5"
       }
     },
     "node_modules/@tapjs/test": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@tapjs/test/-/test-4.0.2.tgz",
-      "integrity": "sha512-J8WOSesfqp6/P5UbChDI5xzREQ96787ZFHLliPva4oi5XevG1TWtfSL47HtbQUtKvWSC7YIWW3CQhcBHRGk6Vg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@tapjs/test/-/test-4.0.5.tgz",
+      "integrity": "sha512-KmCSMWBXMX+uRbSHPAgFCO7ndWekGm8laHcPWURLTxPqLPEjQz3uT8IxBwHHA8Rq5zj/My6nxDox4w/kHaWiYw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/ts-node-temp-fork-for-pr-2009": "^10.9.7",
-        "@tapjs/after": "3.0.2",
-        "@tapjs/after-each": "4.0.2",
-        "@tapjs/asserts": "4.0.2",
-        "@tapjs/before": "4.0.2",
-        "@tapjs/before-each": "4.0.2",
-        "@tapjs/chdir": "3.0.2",
-        "@tapjs/filter": "4.0.2",
-        "@tapjs/fixture": "4.0.2",
-        "@tapjs/intercept": "4.0.2",
-        "@tapjs/mock": "4.0.2",
-        "@tapjs/node-serialize": "4.0.2",
-        "@tapjs/snapshot": "4.0.2",
-        "@tapjs/spawn": "4.0.2",
-        "@tapjs/stdin": "4.0.2",
-        "@tapjs/typescript": "3.1.1",
-        "@tapjs/worker": "4.0.2",
-        "glob": "^11.0.3",
+        "@tapjs/after": "3.0.5",
+        "@tapjs/after-each": "4.0.5",
+        "@tapjs/asserts": "4.0.5",
+        "@tapjs/before": "4.0.5",
+        "@tapjs/before-each": "4.0.5",
+        "@tapjs/chdir": "3.0.5",
+        "@tapjs/filter": "4.0.5",
+        "@tapjs/fixture": "4.0.5",
+        "@tapjs/intercept": "4.0.5",
+        "@tapjs/mock": "4.0.5",
+        "@tapjs/node-serialize": "4.0.5",
+        "@tapjs/snapshot": "4.0.5",
+        "@tapjs/spawn": "4.0.5",
+        "@tapjs/stdin": "4.0.5",
+        "@tapjs/typescript": "3.1.4",
+        "@tapjs/worker": "4.0.5",
+        "glob": "^12.0.0",
         "jackspeak": "^4.0.1",
         "mkdirp": "^3.0.0",
         "package-json-from-dist": "^1.0.0",
         "resolve-import": "^2.0.0",
         "rimraf": "^6.0.0",
         "sync-content": "^2.0.1",
-        "tap-parser": "18.0.1",
+        "tap-parser": "18.0.2",
         "tshy": "^3.0.3",
         "typescript": "5.9",
         "walk-up-path": "^4.0.0"
@@ -1151,13 +1132,13 @@
         "node": "20 || >=22"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.0.2"
+        "@tapjs/core": "4.0.5"
       }
     },
     "node_modules/@tapjs/typescript": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@tapjs/typescript/-/typescript-3.1.1.tgz",
-      "integrity": "sha512-2fxDTeL8X3sm9g0KnHZSD/p9o8tFWYhswRKUq//jv9FA/4XetsKs+ApddPUJEi3AX8+Ma1P1EzjSy/f0z5KIJA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@tapjs/typescript/-/typescript-3.1.4.tgz",
+      "integrity": "sha512-th2sG2leV+NpD8k47EOJV4q/FrSg/cxMEPCLaiQVVyLUR7vkcql4ts8NpfKkKKtYrWZeVxvxyEPIJJik6tFsRg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -1167,47 +1148,47 @@
         "node": "20 || >=22"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.0.2"
+        "@tapjs/core": "4.0.5"
       }
     },
     "node_modules/@tapjs/worker": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@tapjs/worker/-/worker-4.0.2.tgz",
-      "integrity": "sha512-o2jzyjEnpRf3xHmduIfO/HXb5m9qRz+tCoiiFmPav+LC7eilSrDP3eGiQwMGbew64PK52KQwQW/LYNRrQsuMxA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@tapjs/worker/-/worker-4.0.5.tgz",
+      "integrity": "sha512-DS1ieUV4eNp3G7xshFcPV7l01jSdI9EixeGHZgqwEs7Q9If6QxXyMjjDwOBpI7pVo0YDeyrh/5zs4I8Iwlahdw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.0.2"
+        "@tapjs/core": "4.0.5"
       }
     },
     "node_modules/@tsconfig/node14": {
-      "version": "14.1.5",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-14.1.5.tgz",
-      "integrity": "sha512-hsldDMdbjF18BgvqFX6rHwqb0wlDh4lxyXmo3VATa7LwL4AFrHijv8Or9ySXBSg9TyysRkldJyAC/kplyF/Mmg==",
+      "version": "14.1.7",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-14.1.7.tgz",
+      "integrity": "sha512-kyY72hx3hu02T0a8usd4LAw2/MlcyuVTawMf/Fw4eCvjfshO3Te5dWdpnbJtuBl5JQQ9zaSVI0NunLLmI9K4Hg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.6.tgz",
-      "integrity": "sha512-QXflIthykZUjZMUWp3sKQP8Pikqtncs2KF0iulzsEHXeQI58FH7ypJYHvYEM1CP0RtkNAC70FQOXssQJB+ZZ0Q==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.7.tgz",
+      "integrity": "sha512-X67O+HURaZrfrfKb0ROvrknzF6n0X/6vigqU07mm3hwuCfPCxE9gp/p4WEMp1D8Q357LYc4Nqm2QJq9sTovnZw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node18": {
-      "version": "18.2.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.4.tgz",
-      "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==",
+      "version": "18.2.5",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.5.tgz",
+      "integrity": "sha512-nQicUR0hKCXwCTVByBMPKm+lWH4B+IquC9Y1KEe4oujGVFFKGTIpAFz5z/AwJooSocVAuTSWTe/7ey1nU+xrlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node20": {
-      "version": "20.1.6",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.6.tgz",
-      "integrity": "sha512-sz+Hqx9zwZDpZIV871WSbUzSqNIsXzghZydypnfgzPKLltVJfkINfUeTct31n/tTSa9ZE1ZOfKdRre1uHHquYQ==",
+      "version": "20.1.7",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.7.tgz",
+      "integrity": "sha512-Lt137u6AoCCJNNklpNtfGIYFEywma7Hd3B083jqMga37opSEVw7beWsD4OTXyzKS0I3G2kbQJVoZpOxy9GnxBQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1258,6 +1239,7 @@
       "integrity": "sha512-uWN8YqxXxqFMX2RqGOrumsKeti4LlmIMIyV0lgut4jx7KQBcBiW6vkDtIBvHnHIquwNfJhk8v2OtmO8zXWHfPA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1270,13 +1252,13 @@
       "license": "MIT"
     },
     "node_modules/abbrev": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
-      "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/acorn": {
@@ -1316,9 +1298,9 @@
       }
     },
     "node_modules/ansi-escapes": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.1.1.tgz",
-      "integrity": "sha512-Zhl0ErHcSRUaVfGUeUdDuLgpkEo8KIFjB4Y9uAc46ScOpdDiU1Dbyplh7qWJeJ/ZHpbyMSM26+X3BySgnIz40Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz",
+      "integrity": "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1442,9 +1424,9 @@
       }
     },
     "node_modules/cacache": {
-      "version": "20.0.1",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.1.tgz",
-      "integrity": "sha512-+7LYcYGBYoNqTp1Rv7Ny1YjUo5E0/ftkQtraH3vkfAGgVHc+ouWdC8okAwQgQR7EVIdW6JTzTmhKFwzb+4okAQ==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.2.tgz",
+      "integrity": "sha512-rVWvqtWcgSzB22wImrVto+7PmE+lUqv5dYzRHD0QJsfpSwTkW+GIqA4ykSt/CCjQlQle8USn8CO8vcWNrIqktg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1457,11 +1439,51 @@
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "p-map": "^7.0.2",
-        "ssri": "^12.0.0",
+        "ssri": "^13.0.0",
         "unique-filename": "^4.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/cacache/node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/cacache/node_modules/minimatch": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/chalk": {
@@ -1854,9 +1876,9 @@
       "license": "MIT"
     },
     "node_modules/es-toolkit": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.41.0.tgz",
-      "integrity": "sha512-bDd3oRmbVgqZCJS6WmeQieOrzpl3URcWBUVDXxOELlUW2FuW+0glPOz1n0KnRie+PdyvUZcXz2sOn00c6pPRIA==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.42.0.tgz",
+      "integrity": "sha512-SLHIyY7VfDJBM8clz4+T2oquwTQxEzu263AyhVK4jREOAwJ+8eebaa4wM3nlvnAqhDrMm2EsA6hWHaQsMPQ1nA==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -2017,14 +2039,14 @@
       }
     },
     "node_modules/glob": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
-      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
-      "license": "ISC",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-12.0.0.tgz",
+      "integrity": "sha512-5Qcll1z7IKgHr5g485ePDdHcNQY0k2dtv/bjYy0iuyGxQw2qSOiiXUXJ+AYQpg3HNoUMHqAruX478Jeev7UULw==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "foreground-child": "^3.3.1",
         "jackspeak": "^4.1.1",
-        "minimatch": "^10.0.3",
+        "minimatch": "^10.1.1",
         "minipass": "^7.1.2",
         "package-json-from-dist": "^1.0.0",
         "path-scurry": "^2.0.0"
@@ -2193,13 +2215,13 @@
       }
     },
     "node_modules/ini": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-5.0.0.tgz",
-      "integrity": "sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/ink": {
@@ -2302,9 +2324,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2421,13 +2443,13 @@
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-4.0.0.tgz",
-      "integrity": "sha512-lR4MXjGNgkJc7tkQ97kb2nuEMnNCyU//XYVH0MKTGcXEiSudQ5MKGKen3C5QubYy0vmq+JGitUg92uuywGEwIA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz",
+      "integrity": "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/jsonparse": {
@@ -2517,111 +2539,26 @@
       "license": "ISC"
     },
     "node_modules/make-fetch-happen": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-14.0.3.tgz",
-      "integrity": "sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==",
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.3.tgz",
+      "integrity": "sha512-iyyEpDty1mwW3dGlYXAJqC/azFn5PPvgKVwXayOGBSmKLxhKZ9fg4qIan2ePpp1vJIwfFiO34LAPZgq9SZW9Aw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/agent": "^3.0.0",
-        "cacache": "^19.0.1",
+        "@npmcli/agent": "^4.0.0",
+        "cacache": "^20.0.1",
         "http-cache-semantics": "^4.1.1",
         "minipass": "^7.0.2",
-        "minipass-fetch": "^4.0.0",
+        "minipass-fetch": "^5.0.0",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "negotiator": "^1.0.0",
-        "proc-log": "^5.0.0",
+        "proc-log": "^6.0.0",
         "promise-retry": "^2.0.1",
-        "ssri": "^12.0.0"
+        "ssri": "^13.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/make-fetch-happen/node_modules/cacache": {
-      "version": "19.0.1",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-19.0.1.tgz",
-      "integrity": "sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/fs": "^4.0.0",
-        "fs-minipass": "^3.0.0",
-        "glob": "^10.2.2",
-        "lru-cache": "^10.0.1",
-        "minipass": "^7.0.3",
-        "minipass-collect": "^2.0.1",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "p-map": "^7.0.2",
-        "ssri": "^12.0.0",
-        "tar": "^7.4.3",
-        "unique-filename": "^4.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/make-fetch-happen/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/make-fetch-happen/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/make-fetch-happen/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/make-fetch-happen/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/markdown-it": {
@@ -2676,6 +2613,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -2694,9 +2632,9 @@
       }
     },
     "node_modules/minipass-fetch": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-4.0.1.tgz",
-      "integrity": "sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.0.tgz",
+      "integrity": "sha512-fiCdUALipqgPWrOVTz9fw0XhcazULXOSU6ie40DDbX1F49p1dBrSRBuswndTx1x3vEb/g0FT7vC4c4C2u/mh3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2705,7 +2643,7 @@
         "minizlib": "^3.0.1"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       },
       "optionalDependencies": {
         "encoding": "^0.1.13"
@@ -2856,28 +2794,28 @@
       }
     },
     "node_modules/node-gyp": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-11.5.0.tgz",
-      "integrity": "sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.1.0.tgz",
+      "integrity": "sha512-W+RYA8jBnhSr2vrTtlPYPc1K+CSjGpVDRZxcqJcERZ8ND3A1ThWPHRwctTx3qC3oW99jt726jhdz3Y6ky87J4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^14.0.3",
-        "nopt": "^8.0.0",
-        "proc-log": "^5.0.0",
+        "make-fetch-happen": "^15.0.0",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "tar": "^7.4.3",
+        "tar": "^7.5.2",
         "tinyglobby": "^0.2.12",
-        "which": "^5.0.0"
+        "which": "^6.0.0"
       },
       "bin": {
         "node-gyp": "bin/node-gyp.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/node-gyp/node_modules/isexe": {
@@ -2891,9 +2829,9 @@
       }
     },
     "node_modules/node-gyp/node_modules/which": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.0.tgz",
+      "integrity": "sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2903,36 +2841,36 @@
         "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/nopt": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
-      "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "abbrev": "^3.0.0"
+        "abbrev": "^4.0.0"
       },
       "bin": {
         "nopt": "bin/nopt.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm-bundled": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-4.0.0.tgz",
-      "integrity": "sha512-IxaQZDMsqfQ2Lz37VvyyEtKLe8FsRZuysmedy/N06TU1RyVppYKXrO4xIhR0F+7ubIBox6Q7nir6fQI3ej39iA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-5.0.0.tgz",
+      "integrity": "sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "npm-normalize-package-bin": "^4.0.0"
+        "npm-normalize-package-bin": "^5.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm-install-checks": {
@@ -2949,26 +2887,26 @@
       }
     },
     "node_modules/npm-normalize-package-bin": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-4.0.0.tgz",
-      "integrity": "sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
+      "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm-package-arg": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.1.tgz",
-      "integrity": "sha512-6zqls5xFvJbgFjB1B2U6yITtyGBjDBORB7suI4zA4T/sZ1OmkMFlaQSNB/4K0LtXNA1t4OprAFxPisadK5O2ag==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
+      "integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "hosted-git-info": "^9.0.0",
-        "proc-log": "^5.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "validate-npm-package-name": "^6.0.0"
+        "validate-npm-package-name": "^7.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -2984,16 +2922,6 @@
         "ignore-walk": "^8.0.0",
         "proc-log": "^6.0.0"
       },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm-packlist/node_modules/proc-log": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.0.0.tgz",
-      "integrity": "sha512-KG/XsTDN901PNfPfAMmj6N/Ywg9tM+bHK8pAz+27fS4N4Pcr+4zoYBOcGSBu6ceXYNPxkLpa4ohtfxV1XcLAfA==",
-      "dev": true,
-      "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -3014,71 +2942,21 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm-pick-manifest/node_modules/npm-normalize-package-bin": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
-      "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/npm-registry-fetch": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-19.1.0.tgz",
-      "integrity": "sha512-xyZLfs7TxPu/WKjHUs0jZOPinzBAI32kEUel6za0vH+JUTnFZ5zbHI1ZoGZRDm6oMjADtrli6FxtMlk/5ABPNw==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-19.1.1.tgz",
+      "integrity": "sha512-TakBap6OM1w0H73VZVDf44iFXsOS3h+L4wVMXmbWOQroZgFhMch0juN6XSzBNlD965yIKvWg2dfu7NSiaYLxtw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/redact": "^3.0.0",
+        "@npmcli/redact": "^4.0.0",
         "jsonparse": "^1.3.1",
         "make-fetch-happen": "^15.0.0",
         "minipass": "^7.0.2",
-        "minipass-fetch": "^4.0.0",
+        "minipass-fetch": "^5.0.0",
         "minizlib": "^3.0.1",
         "npm-package-arg": "^13.0.0",
-        "proc-log": "^5.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm-registry-fetch/node_modules/@npmcli/agent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
-      "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.1",
-        "lru-cache": "^11.2.1",
-        "socks-proxy-agent": "^8.0.3"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm-registry-fetch/node_modules/make-fetch-happen": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.2.tgz",
-      "integrity": "sha512-sI1NY4lWlXBAfjmCtVWIIpBypbBdhHtcjnwnv+gtCnsaOffyFil3aidszGC8hgzJe+fT1qix05sWxmD/Bmf/oQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/agent": "^4.0.0",
-        "cacache": "^20.0.1",
-        "http-cache-semantics": "^4.1.1",
-        "minipass": "^7.0.2",
-        "minipass-fetch": "^4.0.0",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^1.0.0",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
-        "ssri": "^12.0.0"
+        "proc-log": "^6.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -3143,9 +3021,9 @@
       }
     },
     "node_modules/p-map": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
-      "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3162,16 +3040,16 @@
       "license": "BlueOak-1.0.0"
     },
     "node_modules/pacote": {
-      "version": "21.0.3",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.0.3.tgz",
-      "integrity": "sha512-itdFlanxO0nmQv4ORsvA9K1wv40IPfB9OmWqfaJWvoJ30VKyHsqNgDVeG+TVhI7Gk7XW8slUy7cA9r6dF5qohw==",
+      "version": "21.0.4",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.0.4.tgz",
+      "integrity": "sha512-RplP/pDW0NNNDh3pnaoIWYPvNenS7UqMbXyvMqJczosiFWTeGGwJC2NQBLqKf4rGLFfwCOnntw1aEp9Jiqm1MA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/git": "^7.0.0",
-        "@npmcli/installed-package-contents": "^3.0.0",
+        "@npmcli/installed-package-contents": "^4.0.0",
         "@npmcli/package-json": "^7.0.0",
-        "@npmcli/promise-spawn": "^8.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
         "@npmcli/run-script": "^10.0.0",
         "cacache": "^20.0.0",
         "fs-minipass": "^3.0.0",
@@ -3180,10 +3058,10 @@
         "npm-packlist": "^10.0.1",
         "npm-pick-manifest": "^11.0.1",
         "npm-registry-fetch": "^19.0.0",
-        "proc-log": "^5.0.0",
+        "proc-log": "^6.0.0",
         "promise-retry": "^2.0.1",
         "sigstore": "^4.0.0",
-        "ssri": "^12.0.0",
+        "ssri": "^13.0.0",
         "tar": "^7.4.3"
       },
       "bin": {
@@ -3223,9 +3101,9 @@
       }
     },
     "node_modules/path-scurry": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
-      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -3244,6 +3122,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3266,6 +3145,7 @@
       "resolved": "https://registry.npmjs.org/polite-json/-/polite-json-5.0.0.tgz",
       "integrity": "sha512-OLS/0XeUAcE8a2fdwemNja+udKgXNnY6yKVIXqAD2zVRx1KvY6Ato/rZ2vdzbxqYwPW0u6SCNC/bAMPNzpzxbw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       },
@@ -3318,13 +3198,13 @@
       }
     },
     "node_modules/proc-log": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
-      "integrity": "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.0.0.tgz",
+      "integrity": "sha512-KG/XsTDN901PNfPfAMmj6N/Ywg9tM+bHK8pAz+27fS4N4Pcr+4zoYBOcGSBu6ceXYNPxkLpa4ohtfxV1XcLAfA==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/process-on-spawn": {
@@ -3369,6 +3249,7 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3472,6 +3353,46 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/resolve-import/node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/resolve-import/node_modules/minimatch": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
@@ -3507,17 +3428,57 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
-      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.0.tgz",
+      "integrity": "sha512-DxdlA1bdNzkZK7JiNWH+BAx1x4tEJWoTofIopFo6qWUU94jYrFZ0ubY05TqH3nWPJ1nKa1JWVFDINZ3fnrle/A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "glob": "^11.0.0",
-        "package-json-from-dist": "^1.0.0"
+        "glob": "^11.0.3",
+        "package-json-from-dist": "^1.0.1"
       },
       "bin": {
         "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
       },
       "engines": {
         "node": "20 || >=22"
@@ -3719,16 +3680,16 @@
       "license": "CC0-1.0"
     },
     "node_modules/ssri": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-12.0.0.tgz",
-      "integrity": "sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.0.tgz",
+      "integrity": "sha512-yizwGBpbCn4YomB2lzhZqrHLJoqFGXihNbib3ozhqF/cIp5ue+xSmOQrjNasEE62hFxsCcg/V/z23t4n8jMEng==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^7.0.3"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/stack-utils": {
@@ -3892,32 +3853,72 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/tap": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/tap/-/tap-21.1.1.tgz",
-      "integrity": "sha512-WQQkoJw2LbusXPq9d6A3N4SHCpiog1AbjSVyNlqRh6uiCrtra24bZRCURX8cgBjKV4W22dcRevvhMp24+N/oVg==",
+    "node_modules/sync-content/node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@tapjs/after": "3.0.2",
-        "@tapjs/after-each": "4.0.2",
-        "@tapjs/asserts": "4.0.2",
-        "@tapjs/before": "4.0.2",
-        "@tapjs/before-each": "4.0.2",
-        "@tapjs/chdir": "3.0.2",
-        "@tapjs/core": "4.0.2",
-        "@tapjs/filter": "4.0.2",
-        "@tapjs/fixture": "4.0.2",
-        "@tapjs/intercept": "4.0.2",
-        "@tapjs/mock": "4.0.2",
-        "@tapjs/node-serialize": "4.0.2",
-        "@tapjs/run": "4.0.3",
-        "@tapjs/snapshot": "4.0.2",
-        "@tapjs/spawn": "4.0.2",
-        "@tapjs/stdin": "4.0.2",
-        "@tapjs/test": "4.0.2",
-        "@tapjs/typescript": "3.1.1",
-        "@tapjs/worker": "4.0.2",
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sync-content/node_modules/minimatch": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tap": {
+      "version": "21.1.4",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-21.1.4.tgz",
+      "integrity": "sha512-JekoWS57oUnVitUAHtxDwJDNq57+wCWQMEh36Nj9t4x+NCuAAo2+jhDd9NUjvUpexO3NQ6FWSpIPv7u6hOf9CA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@tapjs/after": "3.0.5",
+        "@tapjs/after-each": "4.0.5",
+        "@tapjs/asserts": "4.0.5",
+        "@tapjs/before": "4.0.5",
+        "@tapjs/before-each": "4.0.5",
+        "@tapjs/chdir": "3.0.5",
+        "@tapjs/core": "4.0.5",
+        "@tapjs/filter": "4.0.5",
+        "@tapjs/fixture": "4.0.5",
+        "@tapjs/intercept": "4.0.5",
+        "@tapjs/mock": "4.0.5",
+        "@tapjs/node-serialize": "4.0.5",
+        "@tapjs/run": "4.0.6",
+        "@tapjs/snapshot": "4.0.5",
+        "@tapjs/spawn": "4.0.5",
+        "@tapjs/stdin": "4.0.5",
+        "@tapjs/test": "4.0.5",
+        "@tapjs/typescript": "3.1.4",
+        "@tapjs/worker": "4.0.5",
         "resolve-import": "2"
       },
       "bin": {
@@ -3931,14 +3932,14 @@
       }
     },
     "node_modules/tap-parser": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-18.0.1.tgz",
-      "integrity": "sha512-Jcu51jzPCDXzuFvyCDGRfJWm2mJ0yRLf+aqWINk4P03HM9uyrq2SLavn26N8qwVz//GZysNt3DQNvKrYjidB3g==",
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-18.0.2.tgz",
+      "integrity": "sha512-bZvlpCGIQfXXCEvypkRYreETh5hsdRNjTcQHRJr5aCA66BQKwg+7jJ3s1N6Z8AKnNmykofWtYFotHJBWQyV8SA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "events-to-array": "^2.0.3",
-        "tap-yaml": "4.0.1"
+        "tap-yaml": "4.0.2"
       },
       "bin": {
         "tap-parser": "bin/cmd.cjs"
@@ -3948,9 +3949,9 @@
       }
     },
     "node_modules/tap-yaml": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/tap-yaml/-/tap-yaml-4.0.1.tgz",
-      "integrity": "sha512-2D5FSjxSP8v3LCh3N1KZa+FoIaVh2f7bFaUNd4mm74Kx/a5JqKu6QspEQZpAwH1Ez2SlbguOMWKHPTels2xbzA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/tap-yaml/-/tap-yaml-4.0.2.tgz",
+      "integrity": "sha512-M1n76i5O4Gc9bUJcK1X3gmya3eevZJ/KZ3A/OMSQVU2fnARy062R9er+keY3113S3APG197DewX8KoDg/3IFHg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -3979,9 +3980,9 @@
       }
     },
     "node_modules/tcompare": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/tcompare/-/tcompare-9.0.1.tgz",
-      "integrity": "sha512-P9i7K3RnKWb3mH0AmDCChVd7FP0LEo4VSBJMhjKB+Rg+Tvq09ytnys8ygsx5ve1di2fI4IW+HhjhIXoeiRVogw==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/tcompare/-/tcompare-9.0.2.tgz",
+      "integrity": "sha512-0rpdsSXdGDqhfCF9EKj82cDiifMWZgKoR7Vk49EKpMtErQUAlsx6VY/whLv4q2qNbZevSSbwV0DFwJVbaATJzQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -4008,9 +4009,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4096,9 +4097,9 @@
       }
     },
     "node_modules/tshy": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tshy/-/tshy-3.0.3.tgz",
-      "integrity": "sha512-bUX6HQCvVdPyPLy2VZuKw95CtYD5aRSEgYEK7IPV9l9xN/z284kl5/hIwOfLY/mZOOdhrO34dFOOcL1VUMVyaw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tshy/-/tshy-3.1.0.tgz",
+      "integrity": "sha512-DPBaaJSqcKFLSHTiqm3Xl2Phl7m1RtLNMe7J8qyoYO+tb2EW+txRp2NHR746GcrVicUUcNzfpm0yU1suQHRIwQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -4152,46 +4153,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/tuf-js/node_modules/@npmcli/agent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
-      "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.1",
-        "lru-cache": "^11.2.1",
-        "socks-proxy-agent": "^8.0.3"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/tuf-js/node_modules/make-fetch-happen": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.2.tgz",
-      "integrity": "sha512-sI1NY4lWlXBAfjmCtVWIIpBypbBdhHtcjnwnv+gtCnsaOffyFil3aidszGC8hgzJe+fT1qix05sWxmD/Bmf/oQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/agent": "^4.0.0",
-        "cacache": "^20.0.1",
-        "http-cache-semantics": "^4.1.1",
-        "minipass": "^7.0.2",
-        "minipass-fetch": "^4.0.0",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^1.0.0",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
-        "ssri": "^12.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/type-fest": {
       "version": "4.41.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
@@ -4235,6 +4196,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4337,13 +4299,13 @@
       }
     },
     "node_modules/validate-npm-package-name": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-6.0.2.tgz",
-      "integrity": "sha512-IUoow1YUtvoBBC06dXs8bR8B9vuA3aJfmQNKMoaPG/OFsPmoQvw8xh+6Ye25Gx9DQhoEom3Pcu9MKHerm/NpUQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.0.tgz",
+      "integrity": "sha512-bwVk/OK+Qu108aJcMAEiU4yavHUI7aN20TgZNBj9MR2iU1zPUl1Z1Otr7771ExfYTPTvfN8ZJ1pbr5Iklgt4xg==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/walk-up-path": {
@@ -4551,6 +4513,7 @@
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "@types/node": "^24.9.2",
     "mkdirp": "^3.0.1",
     "prettier": "^3.6.2",
-    "tap": "^21.1.1",
-    "tshy": "^3.0.3",
+    "tap": "^21.1.4",
+    "tshy": "^3.1.0",
     "typedoc": "^0.28.14"
   },
   "funding": {
@@ -72,7 +72,7 @@
     "node": "20 || >=22"
   },
   "dependencies": {
-    "glob": "^11.0.3",
+    "glob": "^12.0.0",
     "package-json-from-dist": "^1.0.1"
   },
   "keywords": [


### PR DESCRIPTION
I know it's tedious, but can we update glob to v12 to avoid [this advisory](https://github.com/advisories/GHSA-5j98-mcp5-4vw2)?