### PR TITLE
chore(package.json): upgrade glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "node": "20 || >=22"
   },
   "dependencies": {
-    "glob": "^13.0.3",
+    "glob": "^13.0.6",
     "package-json-from-dist": "^1.0.1"
   },
   "keywords": [


### PR DESCRIPTION
Upgrading `glob` with their patch on minimatch https://github.com/isaacs/node-glob/commit/020c2be44e173be410b73b0fcb73d561cd28e3b0 The patch version fixed a [security issue](https://github.com/isaacs/minimatch/issues/281) in minimatch.

Just noticed that all of these packages are yours 🚀 