### PR TITLE
fix: use HTTPS repository URL instead of SSH

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "description": "A deep deletion module for node (like `rm -rf`)",
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)",
   "license": "BlueOak-1.0.0",
-  "repository": "git@github.com:isaacs/rimraf.git",
+  "repository": "https://github.com/isaacs/rimraf.git",
   "scripts": {
     "preversion": "npm test",
     "postversion": "npm publish",


### PR DESCRIPTION
## Summary

The `repository` field in `package.json` currently uses `git@github.com:isaacs/rimraf.git` which is an SSH-only URL. This requires SSH key configuration to access.

For a public npm package, an HTTPS URL (`https://github.com/isaacs/rimraf.git`) is universally accessible to all users.

## Change
- `git@github.com:isaacs/rimraf.git` → `https://github.com/isaacs/rimraf.git`

No runtime code, dependency, or test changes.