### PR TITLE
test: lock in correct handling of drive-letter paths on win32

### DIFF
--- a/test/path-arg.ts
+++ b/test/path-arg.ts
@@ -19,6 +19,17 @@ for (const platform of ['win32', 'posix'] as const) {
       Error('path must be a string without null bytes'),
     )
     if (platform === 'win32') {
+      // regression test for #325: a well-formed drive-letter path must
+      // NOT be flagged as containing illegal characters just because
+      // the drive prefix itself contains a colon (e.g. "C:")
+      const goodPaths = [
+        'c:\\a\\b\\c',
+        'C:\\Users\\name\\Documents',
+        '\\\\server\\share\\a\\b',
+        ]
+      for (const path of goodPaths) {
+        t.doesNotThrow(() => pathArg(path), `should not throw on ${path}`)
+      }
       const badPaths = [
         'c:\\a\\b:c',
         'c:\\a\\b*c',


### PR DESCRIPTION
Refs #325. pathArg already excludes the drive prefix (e.g. C:\) from the illegal-character check via path.substring(root.length), but there was no test asserting valid drive-letter/UNC paths pass without throwing, only that bad ones fail. This adds that coverage and locks in the current correct behavior.